### PR TITLE
Add support for AWS authentication

### DIFF
--- a/httpx_auth/__init__.py
+++ b/httpx_auth/__init__.py
@@ -17,7 +17,7 @@ from httpx_auth.authentication import (
     OAuth2ResourceOwnerPasswordCredentials,
 )
 from httpx_auth.oauth2_tokens import JsonTokenFileCache
-from httpx_auth.aws4auth import AWS4Auth
+from httpx_auth.aws4auth import AWS4Auth, StrictAWS4Auth
 from httpx_auth.errors import (
     GrantNotProvided,
     TimeoutOccurred,

--- a/httpx_auth/__init__.py
+++ b/httpx_auth/__init__.py
@@ -17,6 +17,7 @@ from httpx_auth.authentication import (
     OAuth2ResourceOwnerPasswordCredentials,
 )
 from httpx_auth.oauth2_tokens import JsonTokenFileCache
+from httpx_auth.aws4auth import AWS4Auth
 from httpx_auth.errors import (
     GrantNotProvided,
     TimeoutOccurred,

--- a/httpx_auth/aws4auth.py
+++ b/httpx_auth/aws4auth.py
@@ -373,7 +373,7 @@ class AWS4Auth(httpx.Auth):
         # in the signed headers, but Requests doesn't include it in a
         # PreparedRequest
         if "host" not in headers:
-            headers["host"] = urlparse(req.url).netloc.split(":")[0]
+            headers["host"] = req.url.host
         # Aggregate for upper/lowercase header name collisions in header names,
         # AMZ requires values of colliding headers be concatenated into a
         # single header with lowercase name.  Although this is not possible with
@@ -505,19 +505,6 @@ class StrictAWS4Auth(AWS4Auth):
         StrictAWS4Auth.regenerate_signing_key().
         """
         raise DateMismatchError
-
-
-class PassiveAWS4Auth(AWS4Auth):
-    """
-    This subclass does not perform any special handling of a mismatched request
-    and scope date, it signs the request and allows Requests to send it. It is
-    up to the calling code to handle a failed authentication response from AWS.
-    This behaviour mimics the behaviour of AWS4Auth for versions 0.7 and
-    earlier.
-    """
-
-    def handle_date_mismatch(self, req):
-        pass
 
 
 class AWS4SigningKey:

--- a/httpx_auth/aws4auth.py
+++ b/httpx_auth/aws4auth.py
@@ -1,0 +1,629 @@
+"""
+Provides code for AWSAuth ported to httpx from Sam Washington's requets-aws4auth
+https://github.com/sam-washington/requests-aws4auth
+"""
+import hmac
+import hashlib
+import posixpath
+import re
+import shlex
+import datetime
+from warnings import warn
+from urllib.parse import urlparse, parse_qs, quote, unquote
+
+import httpx
+
+from typing import Optional, Generator
+
+
+# exceptions
+class RequestsAws4AuthException(Exception):
+    pass
+
+
+class DateMismatchError(RequestsAws4AuthException):
+    pass
+
+
+class NoSecretKeyError(RequestsAws4AuthException):
+    pass
+
+
+class DateFormatError(RequestsAws4AuthException):
+    pass
+
+
+class AWS4Auth(httpx.Auth):
+    """Describes AWS4 authentication for httpx based on requests-aws4auth
+    https://github.com/sam-washington/requests-aws4auth
+    """
+
+    requires_request_body = True
+
+    default_include_headers = ["host", "content-type", "date", "x-amz-*"]
+
+    def __init__(self, *args, **kwargs):
+        """
+        AWS4Auth instances can be created by supplying key scope parameters
+        directly or by using an AWS4SigningKey instance:
+        >>> auth = AWS4Auth(access_id, secret_key, region, service
+        ...                 [, date][, raise_invalid_date=False][, session_token=None])
+          or
+        >>> auth = AWS4Auth(access_id, signing_key[, raise_invalid_date=False])
+        access_id   -- This is your AWS access ID
+        secret_key  -- This is your AWS secret access key
+        region      -- The region you're connecting to, as per the list at
+                       http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+                       e.g. us-east-1. For services which don't require a region
+                       (e.g. IAM), use us-east-1.
+        service     -- The name of the service you're connecting to, as per
+                       endpoints at:
+                       http://docs.aws.amazon.com/general/latest/gr/rande.html
+                       e.g. elasticbeanstalk.
+        date        -- Date this instance is valid for. 8-digit date as str of the
+                       form YYYYMMDD. Key is only valid for requests with a
+                       Date or X-Amz-Date header matching this date. If date is
+                       not supplied the current date is used.
+        signing_key -- An AWS4SigningKey instance.
+        raise_invalid_date
+                    -- Must be supplied as keyword argument. AWS4Auth tries to
+                       parse a date from the X-Amz-Date and Date headers of the
+                       request, first trying X-Amz-Date, and then Date if
+                       X-Amz-Date is not present or is in an unrecognised
+                       format. If one or both of the two headers are present
+                       yet neither are in a format which AWS4Auth recognises
+                       then it will remove both headers and replace with a new
+                       X-Amz-Date header using the current date.
+                       If this behaviour is not wanted, set the
+                       raise_invalid_date keyword argument to True, and
+                       instead an InvalidDateError will be raised when neither
+                       date is recognised. If neither header is present at all
+                       then an X-Amz-Date header will still be added containing
+                       the current date.
+                       See the AWS4Auth class docstring for supported date
+                       formats.
+        session_token
+                    -- Must be supplied as keyword argument. If session_token
+                       is set, then it is used for the x-amz-security-token
+                       header, for use with STS temporary credentials.
+        """
+        l = len(args)
+        if l not in [2, 4, 5]:
+            msg = "AWS4Auth() takes 2, 4 or 5 arguments, {} given".format(l)
+            raise TypeError(msg)
+        self.access_id = args[0]
+        if isinstance(args[1], AWS4SigningKey) and l == 2:
+            # instantiate from signing key
+            self.signing_key = args[1]
+            self.region = self.signing_key.region
+            self.service = self.signing_key.service
+            self.date = self.signing_key.date
+        elif l in [4, 5]:
+            # instantiate from args
+            secret_key = args[1]
+            self.region = args[2]
+            self.service = args[3]
+            self.date = args[4] if l == 5 else None
+            self.signing_key = None
+            self.regenerate_signing_key(secret_key=secret_key)
+        else:
+            raise TypeError()
+
+        raise_invalid_date = kwargs.get("raise_invalid_date", False)
+        if raise_invalid_date in [True, False]:
+            self.raise_invalid_date = raise_invalid_date
+        else:
+            raise ValueError(
+                "raise_invalid_date must be True or False in AWS4Auth.__init__()"
+            )
+
+        self.session_token = kwargs.get("session_token")
+        if self.session_token:
+            self.default_include_headers.append("x-amz-security-token")
+        self.include_hdrs = kwargs.get("include_hdrs", self.default_include_headers)
+
+    def auth_flow(
+        self, request: httpx.Request
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        """
+        Interface used by Httpx module to apply authentication to HTTP
+        requests.
+        Add x-amz-content-sha256 and Authorization headers to the request. Add
+        x-amz-date header to request if not already present and req does not
+        contain a Date header.
+        Check request date matches date in the current signing key. If not,
+        regenerate signing key to match request date.
+        """
+        # check request date matches scope date
+        req_date = self.get_request_date(request)
+        if req_date is None:
+            # no date headers or none in recognisable format
+            # replace them with x-amz-header with current date and time
+            if "date" in request.headers:
+                del request.headers["date"]
+            if "x-amz-date" in request.headers:
+                del request.headers["x-amz-date"]
+            now = datetime.datetime.utcnow()
+            req_date = now.date()
+            request.headers["x-amz-date"] = now.strftime("%Y%m%dT%H%M%SZ")
+        req_scope_date = req_date.strftime("%Y%m%d")
+        if req_scope_date != self.date:
+            self.handle_date_mismatch(request)
+
+        # encode body and generate body hash
+        if hasattr(request, "_content") and request.content is not None:
+            content_hash = hashlib.sha256(request.content)
+        else:
+            content_hash = hashlib.sha256(b"")
+        request.headers["x-amz-content-sha256"] = content_hash.hexdigest()
+        if self.session_token:
+            request.headers["x-amz-security-token"] = self.session_token
+
+        # generate signature
+        result = self.get_canonical_headers(request, self.include_hdrs)
+        cano_headers, signed_headers = result
+        cano_req = self.get_canonical_request(request, cano_headers, signed_headers)
+        sig_string = self.get_sig_string(request, cano_req, self.signing_key.scope)
+        sig_string = sig_string.encode("utf-8")
+        hsh = hmac.new(self.signing_key.key, sig_string, hashlib.sha256)
+        sig = hsh.hexdigest()
+        auth_str = "AWS4-HMAC-SHA256 "
+        auth_str += "Credential={}/{}, ".format(self.access_id, self.signing_key.scope)
+        auth_str += "SignedHeaders={}, ".format(signed_headers)
+        auth_str += "Signature={}".format(sig)
+        request.headers["Authorization"] = auth_str
+        yield request
+
+    def regenerate_signing_key(
+        self, secret_key=None, region=None, service=None, date=None
+    ):
+        """
+        Regenerate the signing key for this instance. Store the new key in
+        signing_key property.
+        Take scope elements of the new key from the equivalent properties
+        (region, service, date) of the current AWS4Auth instance. Scope
+        elements can be overridden for the new key by supplying arguments to
+        this function. If overrides are supplied update the current AWS4Auth
+        instance's equivalent properties to match the new values.
+        If secret_key is not specified use the value of the secret_key property
+        of the current AWS4Auth instance's signing key. If the existing signing
+        key is not storing its secret key (i.e. store_secret_key was set to
+        False at instantiation) then raise a NoSecretKeyError and do not
+        regenerate the key. In order to regenerate a key which is not storing
+        its secret key, secret_key must be supplied to this function.
+        Use the value of the existing key's store_secret_key property when
+        generating the new key. If there is no existing key, then default
+        to setting store_secret_key to True for new key.
+        """
+        if secret_key is None and (
+            self.signing_key is None or self.signing_key.secret_key is None
+        ):
+            raise NoSecretKeyError
+
+        secret_key = secret_key or self.signing_key.secret_key
+        region = region or self.region
+        service = service or self.service
+        date = date or self.date
+        if self.signing_key is None:
+            store_secret_key = True
+        else:
+            store_secret_key = self.signing_key.store_secret_key
+
+        self.signing_key = AWS4SigningKey(
+            secret_key, region, service, date, store_secret_key
+        )
+
+        self.region = region
+        self.service = service
+        self.date = self.signing_key.date
+
+    @classmethod
+    def get_request_date(cls, req):
+        """
+        Try to pull a date from the request by looking first at the
+        x-amz-date header, and if that's not present then the Date header.
+        Return a datetime.date object, or None if neither date header
+        is found or is in a recognisable format.
+        req -- a requests PreparedRequest object
+        """
+        date = None
+        for header in ["x-amz-date", "date"]:
+            if header not in req.headers:
+                continue
+            try:
+                date_str = cls.parse_date(req.headers[header])
+            except DateFormatError:
+                continue
+            try:
+                date = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
+            except ValueError:
+                continue
+            else:
+                break
+
+        return date
+
+    @staticmethod
+    def parse_date(date_str):
+        """
+        Check if date_str is in a recognised format and return an ISO
+        yyyy-mm-dd format version if so. Raise DateFormatError if not.
+        Recognised formats are:
+        * RFC 7231 (e.g. Mon, 09 Sep 2011 23:36:00 GMT)
+        * RFC 850 (e.g. Sunday, 06-Nov-94 08:49:37 GMT)
+        * C time (e.g. Wed Dec 4 00:00:00 2002)
+        * Amz-Date format (e.g. 20090325T010101Z)
+        * ISO 8601 / RFC 3339 (e.g. 2009-03-25T10:11:12.13-01:00)
+        date_str -- Str containing a date and optional time
+        """
+        months = [
+            "jan",
+            "feb",
+            "mar",
+            "apr",
+            "may",
+            "jun",
+            "jul",
+            "aug",
+            "sep",
+            "oct",
+            "nov",
+            "dec",
+        ]
+        formats = {
+            # RFC 7231, e.g. 'Mon, 09 Sep 2011 23:36:00 GMT'
+            r"^(?:\w{3}, )?(\d{2}) (\w{3}) (\d{4})\D.*$": lambda m: (
+                "{}-{:02d}-{}".format(
+                    m.group(3), months.index(m.group(2).lower()) + 1, m.group(1)
+                )
+            ),
+            # RFC 850 (e.g. Sunday, 06-Nov-94 08:49:37 GMT)
+            # assumes current century
+            r"^\w+day, (\d{2})-(\w{3})-(\d{2})\D.*$": lambda m: "{}{}-{:02d}-{}".format(
+                str(datetime.date.today().year)[:2],
+                m.group(3),
+                months.index(m.group(2).lower()) + 1,
+                m.group(1),
+            ),
+            # C time, e.g. 'Wed Dec 4 00:00:00 2002'
+            r"^\w{3} (\w{3}) (\d{1,2}) \d{2}:\d{2}:\d{2} (\d{4})$": lambda m: (
+                "{}-{:02d}-{:02d}".format(
+                    m.group(3), months.index(m.group(1).lower()) + 1, int(m.group(2))
+                )
+            ),
+            # x-amz-date format dates, e.g. 20100325T010101Z
+            r"^(\d{4})(\d{2})(\d{2})T\d{6}Z$": lambda m: "{}-{}-{}".format(*m.groups()),
+            # ISO 8601 / RFC 3339, e.g. '2009-03-25T10:11:12.13-01:00'
+            r"^(\d{4}-\d{2}-\d{2})(?:[Tt].*)?$": lambda m: m.group(1),
+        }
+
+        out_date = None
+        for regex, xform in formats.items():
+            m = re.search(regex, date_str)
+            if m:
+                out_date = xform(m)
+                break
+        if out_date is None:
+            raise DateFormatError
+        else:
+            return out_date
+
+    def handle_date_mismatch(self, req):
+        """
+        Handle a request whose date doesn't match the signing key scope date.
+        This AWS4Auth class implementation regenerates the signing key. See
+        StrictAWS4Auth class if you would prefer an exception to be raised.
+        req -- a requests prepared request object
+        """
+        req_datetime = self.get_request_date(req)
+        new_key_date = req_datetime.strftime("%Y%m%d")
+        self.regenerate_signing_key(date=new_key_date)
+
+    def get_canonical_request(self, req, cano_headers, signed_headers):
+        """
+        Create the AWS authentication Canonical Request string.
+        req            -- Requests PreparedRequest object. Should already
+                          include an x-amz-content-sha256 header
+        cano_headers   -- Canonical Headers section of Canonical Request, as
+                          returned by get_canonical_headers()
+        signed_headers -- Signed Headers, as returned by
+                          get_canonical_headers()
+        """
+        url_str = str(req.url)
+        url = urlparse(url_str)
+        path = self.amz_cano_path(url.path)
+        # AWS handles "extreme" querystrings differently to urlparse
+        # (see post-vanilla-query-nonunreserved test in aws_testsuite)
+        split = url_str.split("?", 1)
+        qs = split[1] if len(split) == 2 else ""
+        qs = self.amz_cano_querystring(qs)
+        payload_hash = req.headers["x-amz-content-sha256"]
+        req_parts = [
+            req.method.upper(),
+            path,
+            qs,
+            cano_headers,
+            signed_headers,
+            payload_hash,
+        ]
+        cano_req = "\n".join(req_parts)
+        return cano_req
+
+    @classmethod
+    def get_canonical_headers(cls, req, include=None):
+        """
+        Generate the Canonical Headers section of the Canonical Request.
+        Return the Canonical Headers and the Signed Headers strs as a tuple
+        (canonical_headers, signed_headers).
+        req     -- Requests PreparedRequest object
+        include -- List of headers to include in the canonical and signed
+                   headers. It's primarily included to allow testing against
+                   specific examples from Amazon. If omitted or None it
+                   includes host, content-type and any header starting 'x-amz-'
+                   except for x-amz-client context, which appears to break
+                   mobile analytics auth if included. Except for the
+                   x-amz-client-context exclusion these defaults are per the
+                   AWS documentation.
+        """
+        if include is None:
+            include = cls.default_include_headers
+        include = [x.lower() for x in include]
+        headers = req.headers.copy()
+        # Temporarily include the host header - AWS requires it to be included
+        # in the signed headers, but Requests doesn't include it in a
+        # PreparedRequest
+        if "host" not in headers:
+            headers["host"] = urlparse(req.url).netloc.split(":")[0]
+        # Aggregate for upper/lowercase header name collisions in header names,
+        # AMZ requires values of colliding headers be concatenated into a
+        # single header with lowercase name.  Although this is not possible with
+        # Requests, since it uses a case-insensitive dict to hold headers, this
+        # is here just in case you duck type with a regular dict
+        cano_headers_dict = {}
+        for hdr, val in headers.items():
+            hdr = hdr.strip().lower()
+            val = cls.amz_norm_whitespace(val).strip()
+            if (
+                hdr in include
+                or "*" in include
+                or (
+                    "x-amz-*" in include
+                    and hdr.startswith("x-amz-")
+                    and not hdr == "x-amz-client-context"
+                )
+            ):
+                vals = cano_headers_dict.setdefault(hdr, [])
+                vals.append(val)
+        # Flatten cano_headers dict to string and generate signed_headers
+        cano_headers = ""
+        signed_headers_list = []
+        for hdr in sorted(cano_headers_dict):
+            vals = cano_headers_dict[hdr]
+            val = ",".join(sorted(vals))
+            cano_headers += "{}:{}\n".format(hdr, val)
+            signed_headers_list.append(hdr)
+        signed_headers = ";".join(signed_headers_list)
+        return (cano_headers, signed_headers)
+
+    @staticmethod
+    def get_sig_string(req, cano_req, scope):
+        """
+        Generate the AWS4 auth string to sign for the request.
+        req      -- Requests PreparedRequest object. This should already
+                    include an x-amz-date header.
+        cano_req -- The Canonical Request, as returned by
+                    get_canonical_request()
+        """
+        amz_date = req.headers["x-amz-date"]
+        hsh = hashlib.sha256(cano_req.encode())
+        sig_items = ["AWS4-HMAC-SHA256", amz_date, scope, hsh.hexdigest()]
+        sig_string = "\n".join(sig_items)
+        return sig_string
+
+    def amz_cano_path(self, path):
+        """
+        Generate the canonical path as per AWS4 auth requirements.
+        Not documented anywhere, determined from aws4_testsuite examples,
+        problem reports and testing against the live services.
+        path -- request path
+        """
+        safe_chars = "/~"
+        qs = ""
+        fixed_path = path
+        if "?" in fixed_path:
+            fixed_path, qs = fixed_path.split("?", 1)
+        fixed_path = posixpath.normpath(fixed_path)
+        fixed_path = re.sub("/+", "/", fixed_path)
+        if path.endswith("/") and not fixed_path.endswith("/"):
+            fixed_path += "/"
+        full_path = fixed_path
+        # S3 seems to require unquoting first. 'host' service is used in
+        # amz_testsuite tests
+        if self.service in ["s3", "host"]:
+            full_path = unquote(full_path)
+        full_path = quote(full_path, safe=safe_chars)
+        if qs:
+            qm = "?"
+            full_path = qm.join((full_path, qs))
+        return full_path
+
+    @staticmethod
+    def amz_cano_querystring(qs):
+        """
+        Parse and format querystring as per AWS4 auth requirements.
+        Perform percent quoting as needed.
+        qs -- querystring
+        """
+        safe_qs_amz_chars = "&=+"
+        safe_qs_unresvd = "-_.~"
+        qs = unquote(qs)
+        space = " "
+        qs = qs.split(space)[0]
+        qs = quote(qs, safe=safe_qs_amz_chars)
+        qs_items = {}
+        for name, vals in parse_qs(qs, keep_blank_values=True).items():
+            name = quote(name, safe=safe_qs_unresvd)
+            vals = [quote(val, safe=safe_qs_unresvd) for val in vals]
+            qs_items[name] = vals
+        qs_strings = []
+        for name, vals in qs_items.items():
+            for val in vals:
+                qs_strings.append("=".join([name, val]))
+        qs = "&".join(sorted(qs_strings))
+        return qs
+
+    @staticmethod
+    def amz_norm_whitespace(text):
+        """
+        Replace runs of whitespace with a single space.
+        Ignore text enclosed in quotes.
+        """
+        return " ".join(shlex.split(text, posix=False))
+
+
+class StrictAWS4Auth(AWS4Auth):
+    """
+    Instances of this subclass will not automatically regenerate their signing
+    keys when asked to sign a request whose date does not match the scope date
+    of the signing key. Instances will instead raise a DateMismatchError.
+    Keys of StrictAWSAuth instances can be regenerated manually by calling the
+    regenerate_signing_key() method.
+    Keys will still store the secret key by default. If this is not desired
+    then create the instance by passing an AWS4SigningKey created with
+    store_secret_key set to False to the StrictAWS4AUth constructor:
+    >>> sig_key = AWS4SigningKey(secret_key, region, service, date, False)
+    >>> auth = StrictAWS4Auth(access_id, sig_key)
+    """
+
+    def handle_date_mismatch(self, req):
+        """
+        Handle a request whose date doesn't match the signing key process, by
+        raising a DateMismatchError.
+        Overrides the default behaviour of AWS4Auth where the signing key
+        is automatically regenerated to match the request date
+        To update the signing key if this is hit, call
+        StrictAWS4Auth.regenerate_signing_key().
+        """
+        raise DateMismatchError
+
+
+class PassiveAWS4Auth(AWS4Auth):
+    """
+    This subclass does not perform any special handling of a mismatched request
+    and scope date, it signs the request and allows Requests to send it. It is
+    up to the calling code to handle a failed authentication response from AWS.
+    This behaviour mimics the behaviour of AWS4Auth for versions 0.7 and
+    earlier.
+    """
+
+    def handle_date_mismatch(self, req):
+        pass
+
+
+class AWS4SigningKey:
+    """
+    AWS signing key. Used to sign AWS authentication strings.
+    The secret key is stored in the instance after instantiation, this can be
+    changed via the store_secret_key argument, see below for details.
+    Methods:
+    generate_key() -- Generate AWS4 Signing Key string
+    sign_sha256()  -- Generate SHA256 HMAC signature, encoding message to bytes
+                      first if required
+    Attributes:
+    region   -- AWS region the key is scoped for
+    service  -- AWS service the key is scoped for
+    date     -- Date the key is scoped for
+    scope    -- The AWS scope string for this key, calculated from the above
+                attributes
+    key      -- The signing key string itself
+    amz_date -- Deprecated name for 'date'. Use the 'date' attribute instead.
+                amz_date will be removed in a future version.
+    """
+
+    def __init__(self, secret_key, region, service, date=None, store_secret_key=True):
+        """
+        >>> AWS4SigningKey(secret_key, region, service[, date]
+        ...                [, store_secret_key])
+        secret_key -- This is your AWS secret access key
+        region     -- The region you're connecting to, as per list at
+                      http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+                      e.g. us-east-1. For services which don't require a
+                      region (e.g. IAM), use us-east-1.
+        service    -- The name of the service you're connecting to, as per
+                      endpoints at:
+                      http://docs.aws.amazon.com/general/latest/gr/rande.html
+                      e.g. elasticbeanstalk
+        date       -- 8-digit date of the form YYYYMMDD. Key is only valid for
+                      requests with a Date or X-Amz-Date header matching this
+                      date. If date is not supplied the current date is
+                      used.
+        store_secret_key
+                   -- Whether the secret key is stored in the instance. By
+                      default this is True, meaning the key is stored in
+                      the secret_key property and is available to any
+                      code the instance is passed to. Having the secret
+                      key retained makes it easier to regenerate the key
+                      if a scope parameter changes (usually the date).
+                      This is used by the AWS4Auth class to perform its
+                      automatic key updates when a request date/scope date
+                      mismatch is encountered.
+                      If you are passing instances to untrusted code you can
+                      set this to False. This will cause the secret key to be
+                      discarded as soon as the signing key has been generated.
+                      Note though that you will need to manually regenerate
+                      keys when needed (or if you use the regenerate_key()
+                      method on an AWS4Auth instance you will need to pass it
+                      the secret key).
+        All arguments should be supplied as strings.
+        """
+
+        self.region = region
+        self.service = service
+        self.date = date or datetime.datetime.utcnow().strftime("%Y%m%d")
+        self.scope = "{}/{}/{}/aws4_request".format(
+            self.date, self.region, self.service
+        )
+        self.store_secret_key = store_secret_key
+        self.secret_key = secret_key if self.store_secret_key else None
+        self.key = self.generate_key(secret_key, self.region, self.service, self.date)
+
+    @classmethod
+    def generate_key(cls, secret_key, region, service, date, intermediates=False):
+        """
+        Generate the signing key string as bytes.
+        If intermediate is set to True, returns a 4-tuple containing the key
+        and the intermediate keys:
+        ( signing_key, date_key, region_key, service_key )
+        The intermediate keys can be used for testing against examples from
+        Amazon.
+        """
+        init_key = ("AWS4" + secret_key).encode("utf-8")
+        date_key = cls.sign_sha256(init_key, date)
+        region_key = cls.sign_sha256(date_key, region)
+        service_key = cls.sign_sha256(region_key, service)
+        key = cls.sign_sha256(service_key, "aws4_request")
+        if intermediates:
+            return (key, date_key, region_key, service_key)
+        else:
+            return key
+
+    @staticmethod
+    def sign_sha256(key, msg):
+        """
+        Generate an SHA256 HMAC, encoding msg to UTF-8 if not
+        already encoded.
+        key -- signing key. bytes.
+        msg -- message to sign. unicode or bytes.
+        """
+        if isinstance(msg, str):
+            msg = msg.encode("utf-8")
+        return hmac.new(key, msg, hashlib.sha256).digest()
+
+    @property
+    def amz_date(self):
+        msg = (
+            "This attribute has been renamed to 'date'. 'amz_date' is "
+            "deprecated and will be removed in a future version."
+        )
+        warn(msg, DeprecationWarning)
+        return self.date

--- a/tests/test_aws4auth.py
+++ b/tests/test_aws4auth.py
@@ -1052,7 +1052,6 @@ class AWS4Auth_RequestSign_Test(unittest.TestCase):
         req.headers["x-amz-content-sha256"] = hsh.hexdigest()
         sreq = next(auth.auth_flow(req))
         signature = sreq.headers["Authorization"].split("=")[3]
-        print(sreq.headers["Authorization"])
         expected = "d50ec75eed10aeb2cb3ddf6702d65d3bce310464d99da6f1af092bbc0f238295"
         self.assertEqual(signature, expected)
 
@@ -1189,7 +1188,7 @@ class AWS4Auth_LiveService_Test(unittest.TestCase):
     services = {
         #   "AppStream": "appstream2.us-east-1.amazonaws.com/applications",
         "Auto-Scaling": "autoscaling.us-east-1.amazonaws.com/?Action=DescribeAutoScalingInstances&Version=2011-01-01",
-        # "CloudFormation": "cloudformation.us-east-1.amazonaws.com?Action=ListStacks",
+        # "CloudFormation": "cloudformation.us-east-1.amazonaws.com?Action=ListStacks&Version=2010-05-15&SignatureVersion=4",
         "CloudFront": "cloudfront.amazonaws.com/2014-11-06/distribution?MaxItems=1",
         #  "CloudHSM": {
         #     "method": "POST",
@@ -1390,13 +1389,12 @@ class AWS4Auth_LiveService_Test(unittest.TestCase):
         url = "https://" + path_qs
         region = "us-east-1"
         auth = AWS4Auth(live_access_id, live_secret_key, region, service)
-        print(f"connecting to {url}")
         response = httpx.request(method, url, auth=auth, data=body, headers=headers)
         self.assertEqual(response.status_code, httpx.codes.OK)
 
-    def test_mobileanalytics(self):
-        url = "https://mobileanalytics.us-east-1.amazonaws.com/2014-06-05/events"
-        service = "mobileanalytics"
+    def test_pinpoint(self):
+        url = "https://pinpoint.us-east-1.amazonaws.com/v1/apps"
+        service = "mobiletargeting"
         region = "us-east-1"
         dt = datetime.datetime.utcnow()
         date = dt.strftime("%Y%m%d")
@@ -1405,27 +1403,8 @@ class AWS4Auth_LiveService_Test(unittest.TestCase):
         headers = {
             "Content-Type": "application/json",
             "X-Amz-Date": dt.strftime("%Y%m%dT%H%M%SZ"),
-            "X-Amz-Client-Context": json.dumps(
-                {
-                    "client": {"client_id": "a", "app_title": "a"},
-                    "custom": {},
-                    "env": {"platform": "a"},
-                    "services": {},
-                }
-            ),
         }
-        body = json.dumps(
-            {
-                "events": [
-                    {
-                        "eventType": "a",
-                        "timestamp": dt.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
-                        "session": {},
-                    }
-                ]
-            }
-        )
-        response = httpx.post(url, auth=auth, headers=headers, data=body)
+        response = httpx.get(url, auth=auth, headers=headers)
         self.assertEqual(response.status_code, httpx.codes.OK)
 
 

--- a/tests/test_aws4auth.py
+++ b/tests/test_aws4auth.py
@@ -677,6 +677,14 @@ class AWS4Auth_Date_Test(unittest.TestCase):
         result = AWS4Auth.get_request_date(req)
         self.assertEqual(result, check)
 
+    def test_get_request_date_value_errro(self):
+        check = None
+        req = httpx.Request("GET", "http://blah.com")
+        req.headers["x-amz-date"] = ""
+        req.headers["date"] = "Sun, 05 Jan 0000 01:01:01 GMT"
+        result = AWS4Auth.get_request_date(req)
+        self.assertEqual(result, check)
+
     def test_replace_bad_dates(self):
         req = httpx.Request("GET", "http://blah.com")
         req.headers["x-amz-date"] = ""

--- a/tests/test_aws4auth.py
+++ b/tests/test_aws4auth.py
@@ -832,6 +832,7 @@ class AWS4Auth_GetCanonicalHeaders_Test(unittest.TestCase):
             "My-header1:    a   b   c ",
             "x-amz-date:20120228T030031Z",
             'My-Header2:    "a   b   c"',
+            "user-agent:python-httpx",
         ]
         headers = dict([item.split(":") for item in hdr_text])
         req = httpx.Request("GET", "http://iam.amazonaws.com", headers=headers)
@@ -846,7 +847,7 @@ class AWS4Auth_GetCanonicalHeaders_Test(unittest.TestCase):
             "host:iam.amazonaws.com",
             "my-header1:a b c",
             'my-header2:"a   b   c"',
-            "user-agent:python-httpx/0.12.1",
+            "user-agent:python-httpx",
             "x-amz-date:20120228T030031Z",
         ]
         expected = "\n".join(expected) + "\n"
@@ -971,6 +972,7 @@ class AWS4Auth_RequestSign_Test(unittest.TestCase):
             "POST https://iam.amazonaws.com/ HTTP/1.1",
             "Host: iam.amazonaws.com",
             "Content-Type: application/x-www-form-urlencoded; charset=utf-8",
+            "User-Agent:python-httpx",
             "X-Amz-Date: 20110909T233600Z",
             "",
             "Action=ListUsers&Version=2010-05-08",
@@ -985,9 +987,7 @@ class AWS4Auth_RequestSign_Test(unittest.TestCase):
         sreq = next(auth.auth_flow(req))
         signature = sreq.headers["Authorization"].split("=")[3]
         print(sreq.headers["Authorization"])
-        expected = "d825b8356720a0bd1d1a78d60ae2dbdaf4ed3b13575656448415487371b80376"
-        # expected = "ced6826de92d2bdeed8f846f0bf508e8559e98e4b0199114b84c541" "74deb456c"
-
+        expected = "98ea85c76b6cdfbf10726c3fe0edf82b42be91d2b6622cd427fcad82ab40e25e"
         self.assertEqual(signature, expected)
 
     def test_generate_empty_body_signature(self):

--- a/tests/test_aws4auth.py
+++ b/tests/test_aws4auth.py
@@ -1,0 +1,1353 @@
+from pytest_httpx import httpx_mock, HTTPXMock
+
+import httpx_auth
+
+"""
+Tests for aws4auth support in httpx_auth
+-----------------
+Two major tests are dependent on having a copy of the AWS4 testsuite available.
+Because Amazon hasn't made the licensing conditions clear for this it's not
+included in this source, but it is free to download.
+Download the testsuite zip from here:
+http://docs.aws.amazon.com/general/latest/gr/samples/aws4_testsuite.zip
+Unzip the suite to a folder called aws4_testsuite in this test directory. You
+can use another folder but you'll need to update the path in
+AmzAws4TestSuite.__init__().
+Without the test suite the rest of the tests will still run, but many edge
+cases covered by the suite will be missed.
+Live service tests
+------------------
+This module contains tests against live AWS services. In order to run these
+your AWS access ID and access key need to be specified in the AWS_ACCESS_KEY_ID
+and AWS_SECRET_ACCESS_ID environment variables respectively. This can be done with
+something like:
+$ AWS_ACCESS_KEY_ID='ID' AWS_SECRET_ACCESS_KEY='KEY' python requests_aws4auth_test.py
+If these variables are not provided the rest of the tests will still run but
+the live service tests will be skipped.
+The live tests perform information retrieval operations only, no chargeable
+operations are performed!
+"""
+
+# Licensed under the MIT License:
+# http://opensource.org/licenses/MIT
+
+
+import sys
+import os
+import unittest
+import re
+import hashlib
+import itertools
+import json
+import warnings
+import datetime
+from errno import ENOENT
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
+import httpx
+
+sys.path = ["../../"] + sys.path
+from httpx_auth import AWS4Auth
+from httpx_auth.aws4auth import AWS4SigningKey
+from httpx_auth.aws4auth import DateFormatError, NoSecretKeyError
+
+live_access_id = os.getenv("AWS_ACCESS_KEY_ID")
+live_secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+
+
+class SimpleNamespace:
+    pass
+
+
+class AmzAws4TestSuite:
+    """
+    Load and wrap files from the aws4_testsuite.zip test suite from Amazon.
+    Test suite files are available from:
+    http://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html
+    Methods:
+    load_testsuite_data: Staticmethod. Loads the test suite files found at the
+                         supplied path and returns a dict containing the data.
+    Attributes:
+    access_id:  The AWS access ID used by the test examples in the suite.
+    secret_key: The AWS secret access key used by the test examples in the
+                suite.
+    region:     The AWS region used by the test examples in the suite.
+    service:    The AWS service used by the test examples in the suite.
+    date:       The datestring used by the test examples in the suite
+    timestamp:  The timestamp used by the test examples in the suite
+    path:       The path to the directory containing the test suite files.
+    data:       A dict containing the loaded test file data. See
+                documentation for load_testsuite_data() method for a
+                description of the structure.
+    """
+
+    def __init__(self, path=None):
+        self.access_id = "AKIDEXAMPLE"
+        self.secret_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+        self.region = "us-east-1"
+        self.service = "host"
+        self.date = "20110909"
+        self.timestamp = "20110909T233600Z"
+        self.path = path or "aws4_testsuite"
+        self.data = self.load_testsuite_data(self.path)
+
+    @staticmethod
+    def load_testsuite_data(path):
+        """
+        Return test_suite dict containing grouped test file contents.
+        Return dict is of the form:
+            {'<file group name>': {'<extension>': content,
+                                   '<extension>': content, ...},
+             '<file group name>': {'<extension>': content,
+                                   '<extension>': content, ...},
+             ...
+            }
+        """
+        errmsg = (
+            "Test Suite directory not found. Download the test suite"
+            "from here: http://docs.aws.amazon.com/general/latest/gr/"
+            "samples/aws4_testsuite.zip"
+        )
+        if not os.path.exists(path):
+            raise IOError(ENOENT, errmsg)
+        files = sorted(os.listdir(path))
+        if not files:
+            raise IOError(ENOENT, errmsg)
+        grouped = itertools.groupby(files, lambda x: os.path.splitext(x)[0])
+        data = {}
+        for group_name, items in grouped:
+            if group_name == "get-header-value-multiline":
+                # skipping this test as it is incomplete as supplied in the
+                # test suite
+                continue
+            group = {}
+            for item in items:
+                filepath = os.path.join(path, item)
+                file_ext = os.path.splitext(item)[1]
+                with open(filepath, encoding="utf-8") as f:
+                    content = f.read()
+                group[file_ext] = content
+            data[group_name] = group
+        return data
+
+
+try:
+    amz_aws4_testsuite = AmzAws4TestSuite()
+except IOError as e:
+    if e.errno == ENOENT:
+        amz_aws4_testsuite = None
+    else:
+        raise e
+
+
+def request_from_text(text):
+    """
+    Construct a Requests PreparedRequest using values provided in text.
+    text should be a plaintext HTTP request, as defined in RFC7230.
+    """
+    lines = text.splitlines()
+    match = re.search("^([a-z]+) (.*) (http/[0-9].[0-9])$", lines[0], re.I)
+    method, path, version = match.groups()
+    headers = {}
+    for idx, line in enumerate(lines[1:], start=1):
+        if not line:
+            break
+        hdr, val = [item.strip() for item in line.split(":", 1)]
+        hdr = hdr.lower()
+        vals = headers.setdefault(hdr, [])
+        vals.append(val)
+    headers = {hdr: ",".join(sorted(vals)) for hdr, vals in headers.items()}
+    check_url = urlparse(path)
+    if check_url.scheme and check_url.netloc:
+        # absolute URL in path
+        url = path
+    else:
+        # otherwise need to try to construct url from path and host header
+        url = "".join(
+            ["http://" if "host" in headers else "", headers.get("host", ""), path]
+        )
+    body = "\n".join(lines[idx + 1 :])
+    req = httpx.Request(method, url, headers=headers, data=body)
+    return req
+
+
+class AWS4_SigningKey_Test:
+    def test_basic_instantiation(self):
+        obj = AWS4SigningKey("secret_key", "region", "service", "date")
+        self.assertEqual(obj.region, "region")
+        self.assertEqual(obj.service, "service")
+        self.assertEqual(obj.scope, "date/region/service/aws4_request")
+
+    def test_store_secret_key(self):
+        obj = AWS4SigningKey("secret_key", "region", "service", store_secret_key=True)
+        self.assertEqual(obj.secret_key, "secret_key")
+
+    def test_no_store_secret_key(self):
+        obj = AWS4SigningKey("secret_key", "region", "service", store_secret_key=False)
+        self.assertEqual(obj.secret_key, None)
+
+    def test_default_store_secret_key(self):
+        obj = AWS4SigningKey("secret_key", "region", "service")
+        self.assertEqual(obj.secret_key, "secret_key")
+
+    def test_date(self):
+        test_date = datetime.datetime.utcnow().strftime("%Y%m%d")
+        obj = AWS4SigningKey("secret_key", "region", "service")
+        if obj.date != test_date:
+            test_date = datetime.datetime.utcnow().strftime("%Y%m%d")
+        self.assertEqual(obj.date, test_date)
+
+    def test_amz_date(self):
+        """
+        Will be removed when deprecated amz_date attribute is removed
+        """
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            test_date = datetime.datetime.utcnow().strftime("%Y%m%d")
+            obj = AWS4SigningKey("secret_key", "region", "service")
+            if obj.amz_date != test_date:
+                test_date = datetime.datetime.utcnow().strftime("%Y%m%d")
+            self.assertEqual(obj.amz_date, test_date)
+
+    def test_amz_date_warning(self):
+        """
+        Will be removed when deprecated amz_date attribute is removed
+        """
+        warnings.resetwarnings()
+        with warnings.catch_warnings(record=True) as w:
+            obj = AWS4SigningKey("secret_key", "region", "service")
+            warnings.simplefilter("ignore")
+            self.assertWarns(DeprecationWarning, getattr, obj, "amz_date")
+
+    def test_sign_sha256_unicode_msg(self):
+        key = b"The quick brown fox jumps over the lazy dog"
+        msg = (
+            "Forsaking monastic tradition, twelve jovial friars gave up "
+            "their vocation for a questionable existence on the flying "
+            "trapeze"
+        )
+        expected = [
+            250,
+            103,
+            254,
+            220,
+            118,
+            118,
+            37,
+            81,
+            166,
+            41,
+            65,
+            14,
+            142,
+            77,
+            204,
+            122,
+            185,
+            19,
+            38,
+            15,
+            145,
+            249,
+            113,
+            69,
+            178,
+            30,
+            131,
+            244,
+            230,
+            190,
+            246,
+            23,
+        ]
+        hsh = AWS4SigningKey.sign_sha256(key, msg)
+        hsh = list(hsh)
+        self.assertEqual(hsh, expected)
+
+    def test_sign_sha256_bytes_msg(self):
+        key = b"The quick brown fox jumps over the lazy dog"
+        msg = (
+            b"Forsaking monastic tradition, twelve jovial friars gave up "
+            b"their vocation for a questionable existence on the flying "
+            b"trapeze"
+        )
+        expected = [
+            250,
+            103,
+            254,
+            220,
+            118,
+            118,
+            37,
+            81,
+            166,
+            41,
+            65,
+            14,
+            142,
+            77,
+            204,
+            122,
+            185,
+            19,
+            38,
+            15,
+            145,
+            249,
+            113,
+            69,
+            178,
+            30,
+            131,
+            244,
+            230,
+            190,
+            246,
+            23,
+        ]
+        hsh = AWS4SigningKey.sign_sha256(key, msg)
+        hsh = list(hsh)
+        self.assertEqual(hsh, expected)
+
+    def test_signing_key_phases(self):
+        """
+        Using example data from:
+        http://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html
+        """
+        secret_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+        region = "us-east-1"
+        service = "iam"
+        date = "20120215"
+        # These are signing key, date_key, region_key and service_key
+        # respectively
+        expected_raw = (
+            "f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d",
+            "969fbb94feb542b71ede6f87fe4d5fa29c789342b0f407474670f0c2489e0a0d",
+            "69daa0209cd9c5ff5c8ced464a696fd4252e981430b10e3d3fd8e2f197d7a70c",
+            "f72cfd46f26bc4643f06a11eabb6c0ba18780c19a8da0c31ace671265e3c87fa",
+        )
+        expected = []
+        for hsh in expected_raw:
+            hexen = re.findall("..", hsh)
+            expected.append([int(x, base=16) for x in hexen])
+        result = AWS4SigningKey.generate_key(
+            secret_key, region, service, date, intermediates=True
+        )
+        for i, hsh in enumerate(result):
+            hsh = list(hsh)
+            self.assertEqual(hsh, expected[i], msg="Item number {}".format(i))
+
+    def test_generate_key(self):
+        """
+        Using example data from:
+        http://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
+        """
+        secret_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+        region = "us-east-1"
+        service = "iam"
+        date = "20110909"
+        expected = [
+            152,
+            241,
+            216,
+            137,
+            254,
+            196,
+            244,
+            66,
+            26,
+            220,
+            82,
+            43,
+            171,
+            12,
+            225,
+            248,
+            46,
+            105,
+            41,
+            194,
+            98,
+            237,
+            21,
+            229,
+            169,
+            76,
+            144,
+            239,
+            209,
+            227,
+            176,
+            231,
+        ]
+        key = AWS4SigningKey.generate_key(secret_key, region, service, date)
+        key = list(key)
+        self.assertEqual(key, expected)
+
+    def test_instantiation_generate_key(self):
+        """
+        Using example data from:
+        http://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
+        """
+        secret_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+        region = "us-east-1"
+        service = "iam"
+        date = "20110909"
+        expected = [
+            152,
+            241,
+            216,
+            137,
+            254,
+            196,
+            244,
+            66,
+            26,
+            220,
+            82,
+            43,
+            171,
+            12,
+            225,
+            248,
+            46,
+            105,
+            41,
+            194,
+            98,
+            237,
+            21,
+            229,
+            169,
+            76,
+            144,
+            239,
+            209,
+            227,
+            176,
+            231,
+        ]
+        key = AWS4SigningKey(secret_key, region, service, date).key
+        key = list(key)
+        self.assertEqual(key, expected)
+
+
+class AWS4Auth_Instantiate_Test(unittest.TestCase):
+    def test_instantiate_from_args(self):
+        test_date = datetime.datetime.utcnow().strftime("%Y%m%d")
+        test_inc_hdrs = ["a", "b", "c"]
+        auth = AWS4Auth(
+            "access_id",
+            "secret_key",
+            "region",
+            "service",
+            include_hdrs=test_inc_hdrs,
+            raise_invalid_date=True,
+            session_token="sessiontoken",
+        )
+        self.assertEqual(auth.access_id, "access_id")
+        self.assertEqual(auth.region, "region")
+        self.assertEqual(auth.service, "service")
+        self.assertListEqual(auth.include_hdrs, test_inc_hdrs)
+        self.assertEqual(auth.raise_invalid_date, True)
+        self.assertEqual(auth.session_token, "sessiontoken")
+        self.assertIsInstance(auth.signing_key, AWS4SigningKey)
+        self.assertEqual(auth.signing_key.region, "region")
+        self.assertEqual(auth.signing_key.service, "service")
+        if test_date != auth.signing_key.date:
+            test_date = datetime.datetime.utcnow().strftime("%Y%m%d")
+        self.assertEqual(auth.signing_key.date, test_date)
+        expected = "{}/region/service/aws4_request".format(test_date)
+        self.assertEqual(auth.signing_key.scope, expected)
+
+    def test_instantiate_from_signing_key(self):
+        key = AWS4SigningKey("secret_key", "region", "service", "date")
+        auth = AWS4Auth("access_id", key)
+        self.assertEqual(auth.access_id, "access_id")
+        self.assertEqual(auth.region, "region")
+        self.assertEqual(auth.service, "service")
+        self.assertIsInstance(auth.signing_key, AWS4SigningKey)
+        self.assertEqual(auth.signing_key.region, "region")
+        self.assertEqual(auth.signing_key.service, "service")
+
+    def test_func_signature_check(self):
+        self.assertRaises(TypeError, AWS4Auth, tuple())
+        self.assertRaises(TypeError, AWS4Auth, ("a",))
+        self.assertRaises(TypeError, AWS4Auth, ("a", "a"))
+        self.assertRaises(TypeError, AWS4Auth, ("a", "a", "a"))
+        self.assertRaises(TypeError, AWS4Auth, ("a", "a", "a", "a", "a"))
+
+    def test_raise_invalid_date_default(self):
+        auth = AWS4Auth("access_id", "secret_key", "region", "service")
+        self.assertFalse(auth.raise_invalid_date)
+
+    def test_default_include_hdrs(self):
+        auth = AWS4Auth("access_id", "secret_key", "region", "service")
+        check_set = {"host", "content-type", "date", "x-amz-*"}
+        self.assertSetEqual(set(auth.include_hdrs), check_set)
+
+
+class AWS4Auth_Date_Test(unittest.TestCase):
+    def test_parse_rfc7231(self):
+        tests = {
+            "Sun, 05 Jan 1980 01:01:01 GMT": "1980-01-05",
+            "Mon, 06 Feb 1985 01:01:01 GMT": "1985-02-06",
+            "Tue, 07 Mar 1990 01:01:01 GMT": "1990-03-07",
+            "Wed, 08 Apr 1999 01:01:01 GMT": "1999-04-08",
+            "Thu, 09 May 2000 01:01:01 GMT": "2000-05-09",
+            "Fri, 10 Jun 2100 01:01:01 GMT": "2100-06-10",
+            "Sat, 02 Jul 1900 10:11:12 GMT": "1900-07-02",
+            "Sun, 01 Aug 1970 00:00:00 GMT": "1970-08-01",
+            "Mon, 09 Sep 2011 23:36:00 GMT": "2011-09-09",
+            "Tue, 10 Oct 2000 01:01:01 GMT": "2000-10-10",
+            "Wed, 22 Nov 2015 19:43:01 GMT": "2015-11-22",
+            "Thu, 31 Dec 2130 00:00:00 GMT": "2130-12-31",
+        }
+        for src, check in tests.items():
+            self.assertEqual(AWS4Auth.parse_date(src), check)
+
+    def test_parse_rfc850(self):
+        tests = {
+            "Sunday, 05-Jan-80 01:01:01 GMT": "2080-01-05",
+            "Monday, 06-Feb-85 01:01:01 EST": "2085-02-06",
+            "Tuesday, 07-Mar-90 01:01:01 BST": "2090-03-07",
+            "Wednesday, 08-Apr-99 01:01:01 GMT": "2099-04-08",
+            "Thursday, 09-May-00 01:01:01 GMT": "2000-05-09",
+            "Friday, 10-Jun-00 01:01:01 GMT": "2000-06-10",
+            "Saturday, 02-Jul-00 10:11:12 GMT": "2000-07-02",
+            "Sunday, 01-Aug-70 00:00:00 GMT": "2070-08-01",
+            "Monday, 09-Sep-11 23:36:00 GMT": "2011-09-09",
+            "Tuesday, 10-Oct-00 01:01:01 GMT": "2000-10-10",
+            "Wednesday, 22-Nov-15 19:43:01 GMT": "2015-11-22",
+            "Thursday, 31-Dec-30 00:00:00 GMT": "2030-12-31",
+        }
+        for src, check in tests.items():
+            self.assertEqual(AWS4Auth.parse_date(src), check)
+
+    def test_parse_ctime(self):
+        tests = {
+            "Sun Jan 5 01:01:01 1980": "1980-01-05",
+            "Mon Feb 6 01:01:01 1985": "1985-02-06",
+            "Tue Mar 7 01:01:01 1990": "1990-03-07",
+            "Wed Apr 8 01:01:01 1999": "1999-04-08",
+            "Thu May 9 01:01:01 2000": "2000-05-09",
+            "Fri Jun 10 01:01:01 2100": "2100-06-10",
+            "Sat Jul 2 10:11:12 1900": "1900-07-02",
+            "Sun Aug 1 00:00:00 1970": "1970-08-01",
+            "Mon Sep 9 23:36:00 2011": "2011-09-09",
+            "Tue Oct 10 01:01:01 2000": "2000-10-10",
+            "Wed Nov 22 19:43:01 2015": "2015-11-22",
+            "Thu Dec 31 00:00:00 2130": "2130-12-31",
+        }
+        for src, check in tests.items():
+            self.assertEqual(AWS4Auth.parse_date(src), check)
+
+    def test_parse_amzdate(self):
+        tests = {
+            "19800105T010101Z": "1980-01-05",
+            "19850206T010101Z": "1985-02-06",
+            "19900307T010101Z": "1990-03-07",
+            "19990408T010101Z": "1999-04-08",
+            "20000509T010101Z": "2000-05-09",
+            "21000610T010101Z": "2100-06-10",
+            "19000702T101112Z": "1900-07-02",
+            "19700801T000000Z": "1970-08-01",
+            "20110909T233600Z": "2011-09-09",
+            "20001010T010101Z": "2000-10-10",
+            "20151122T194301Z": "2015-11-22",
+            "21301231T000000Z": "2130-12-31",
+        }
+        for src, check in tests.items():
+            self.assertEqual(AWS4Auth.parse_date(src), check)
+
+    def test_parse_rfc3339(self):
+        tests = {
+            "1980-01-05": "1980-01-05",
+            "1985-02-06T01:01:01+01:00": "1985-02-06",
+            "1990-03-07t02:02:02-09:00": "1990-03-07",
+            "1999-04-08T03:03:03-00:00": "1999-04-08",
+            "2000-05-09t04:04:04Z": "2000-05-09",
+            "2100-06-10T05:05:05Z": "2100-06-10",
+            "1900-07-02T06:06:06Z": "1900-07-02",
+            "1970-08-01T07:07:07Z": "1970-08-01",
+            "2011-09-09T08:08:08Z": "2011-09-09",
+            "2000-10-10T09:09:09Z": "2000-10-10",
+            "2015-11-22T10:10:10Z": "2015-11-22",
+            "2130-12-31T11:11:11Z": "2130-12-31",
+        }
+        for src, check in tests.items():
+            self.assertEqual(AWS4Auth.parse_date(src), check)
+
+    def test_parse_bad_date(self):
+        for date_str in ["failfailfail", "", "111111111", "111-11-11"]:
+            self.assertRaises(DateFormatError, AWS4Auth.parse_date, date_str)
+
+    def test_get_request_date__date_only(self):
+        tests = {
+            "Sun, 05 Jan 1980 01:01:01 GMT": (1980, 1, 5),
+            "19000404T010101Z": (1900, 4, 4),
+            "Monday, 06-Feb-85 01:01:01 EST": (2085, 2, 6),
+            "Sun Jan 5 01:01:01 1980": (1980, 1, 5),
+            "1985-02-06T01:01:01+01:00": (1985, 2, 6),
+        }
+        tests = dict([(k, datetime.date(*v)) for k, v in tests.items()])
+        for date_str, check in tests.items():
+            req = httpx.Request("GET", "http://blah.com")
+            req.headers["date"] = date_str
+            result = AWS4Auth.get_request_date(req)
+            self.assertEqual(result, check, date_str)
+
+    def test_get_request_date__xamzdate_only(self):
+        date_str = "19000404T010101Z"
+        check = datetime.date(1900, 4, 4)
+        req = httpx.Request("GET", "http://blah.com")
+        req.headers["x-amz-date"] = date_str
+        result = AWS4Auth.get_request_date(req)
+        self.assertEqual(result, check, date_str)
+
+    def test_get_request_date__check_prefer_xamzdate(self):
+        xamzdate_str = "19000404T010101Z"
+        check = datetime.date(1900, 4, 4)
+        date_str = "Sun, 05 Jan 1980 01:01:01 GMT"
+        req = httpx.Request("GET", "http://blah.com")
+        req.headers["x-amz-date"] = xamzdate_str
+        req.headers["date"] = date_str
+        result = AWS4Auth.get_request_date(req)
+        self.assertEqual(result, check)
+
+    def test_get_request_date__date_and_invalid_xamzdate(self):
+        xamzdate_str = "19000404X010101Z"
+        date_str = "Sun, 05 Jan 1980 01:01:01 GMT"
+        check = datetime.date(1980, 1, 5)
+        req = httpx.Request("GET", "http://blah.com")
+        req.headers["x-amz-date"] = xamzdate_str
+        req.headers["date"] = date_str
+        result = AWS4Auth.get_request_date(req)
+        self.assertEqual(result, check)
+
+    def test_get_request_date__no_headers(self):
+        req = httpx.Request("GET", "http://blah.com")
+        check = None
+        result = AWS4Auth.get_request_date(req)
+        self.assertEqual(result, check)
+
+    def test_get_request_date__invalid_xamzdate(self):
+        req = httpx.Request("GET", "http://blah.com")
+        req.headers["x-amz-date"] = ""
+        check = None
+        result = AWS4Auth.get_request_date(req)
+        self.assertEqual(result, check)
+
+    def test_get_request_date__invalid_date(self):
+        check = None
+        req = httpx.Request("GET", "http://blah.com")
+        req.headers["date"] = ""
+        result = AWS4Auth.get_request_date(req)
+        self.assertEqual(result, check)
+
+    def test_get_request_date__invalid_both(self):
+        check = None
+        req = httpx.Request("GET", "http://blah.com")
+        req.headers["x-amz-date"] = ""
+        req.headers["date"] = ""
+        result = AWS4Auth.get_request_date(req)
+        self.assertEqual(result, check)
+
+    def test_aws4auth_add_header(self):
+        req = httpx.Request("GET", "http://blah.com")
+        if "date" in req.headers:
+            del req.headers["date"]
+        secret_key = "dummy"
+        region = "us-east-1"
+        service = "iam"
+        key = AWS4SigningKey(secret_key, region, service)
+        auth = AWS4Auth("dummy", key)
+        sreq = next(auth.auth_flow(req))
+        self.assertIn("x-amz-date", sreq.headers)
+        self.assertIsNotNone(AWS4Auth.get_request_date(sreq))
+
+
+class AWS4Auth_Regenerate_Signing_Key_Test(unittest.TestCase):
+    def setUp(self):
+        self.region = "region"
+        self.service = "service"
+        self.date = "19990101"
+        self.secret_key = "secret_key"
+        self.access_id = "access_id"
+        self.auth = AWS4Auth(
+            self.access_id, self.secret_key, self.region, self.service, self.date
+        )
+        self.sig_key_no_secret = AWS4SigningKey(
+            self.secret_key, self.region, self.service, self.date, False
+        )
+        self.auth_no_secret = AWS4Auth(self.access_id, self.sig_key_no_secret)
+
+    def test_regen_signing_key_no_secret_nosecretkey_raise(self):
+        auth = self.auth_no_secret
+        check_id = id(auth.signing_key)
+        self.assertRaises(NoSecretKeyError, auth.regenerate_signing_key)
+        self.assertEqual(id(auth.signing_key), check_id)
+
+    def test_regen_signing_key_no_key_nosecretkey_raise(self):
+        auth = self.auth
+        auth.signing_key = None
+        self.assertRaises(NoSecretKeyError, auth.regenerate_signing_key)
+        self.assertIsNone(auth.signing_key)
+
+    def test_regen_signing_key_new_key(self):
+        auth = self.auth
+        old_id = id(auth.signing_key)
+        auth.regenerate_signing_key()
+        self.assertNotEqual(old_id, id(auth.signing_key))
+
+    def test_regen_signing_key_inherit_previous_scope(self):
+        auth = self.auth
+        auth.regenerate_signing_key()
+        key = auth.signing_key
+        self.assertEqual(key.region, self.region)
+        self.assertEqual(key.service, self.service)
+        self.assertEqual(key.date, self.date)
+        self.assertEqual(key.secret_key, self.secret_key)
+        self.assertEqual(auth.region, self.region)
+        self.assertEqual(auth.service, self.service)
+        self.assertEqual(auth.date, self.date)
+
+    def test_regen_signing_key_use_override_args(self):
+        auth = self.auth
+        new_key = "new_secret_key"
+        new_region = "new_region"
+        new_service = "new_service"
+        new_date = "new_date"
+        auth.regenerate_signing_key(new_key, new_region, new_service, new_date)
+        self.assertEqual(auth.signing_key.secret_key, new_key)
+        self.assertEqual(auth.signing_key.region, new_region)
+        self.assertEqual(auth.signing_key.service, new_service)
+        self.assertEqual(auth.signing_key.date, new_date)
+
+    def test_regen_signing_key_no_key_supplied_secret_key(self):
+        auth = self.auth
+        auth.signing_key = None
+        auth.regenerate_signing_key(self.secret_key)
+        self.assertEqual(auth.signing_key.secret_key, self.secret_key)
+        self.assertEqual(auth.signing_key.region, self.region)
+        self.assertEqual(auth.signing_key.service, self.service)
+        self.assertEqual(auth.signing_key.date, self.date)
+        self.assertTrue(auth.signing_key.store_secret_key)
+
+
+class AWS4Auth_AmzCanonicalPath_Test(unittest.TestCase):
+    def setUp(self):
+        self.nons3auth = AWS4Auth("id", "secret", "us-east-1", "es")
+        self.s3auth = AWS4Auth("id", "secret", "us-east-1", "s3")
+
+    def test_basic(self):
+        path = "/"
+        encoded = self.nons3auth.amz_cano_path(path)
+        self.assertEqual(encoded, path)
+
+    def test_handle_querystring(self):
+        path = "/test/index.html?param1&param2=blah*"
+        encoded = self.nons3auth.amz_cano_path(path)
+        self.assertEqual(encoded, path)
+
+    def test_handle_path_normalization(self):
+        path = "/./test/../stuff//more/"
+        expected = "/stuff/more/"
+        encoded = self.nons3auth.amz_cano_path(path)
+        self.assertEqual(encoded, expected)
+
+    def test_handle_basic_quoting(self):
+        path = "/test/hello-*.&^~+{}!$£_ "
+        expected = "/test/hello-%2A.%26%5E~%2B%7B%7D%21%24%C2%A3_%20"
+        encoded = self.nons3auth.amz_cano_path(path)
+        self.assertEqual(encoded, expected)
+
+    def test_handle_percent_encode_non_s3(self):
+        """
+        Test percent signs are themselves percent encoded for non-S3
+        services.
+        """
+        path = "/test/%2a%2b%25/~-_^& %%"
+        expected = "/test/%252a%252b%2525/~-_%5E%26%20%25%25"
+        auth = AWS4Auth("id", "secret", "us-east-1", "es")
+        encoded = auth.amz_cano_path(path)
+        self.assertEqual(encoded, expected)
+
+    def test_handle_percent_encode_s3(self):
+        """
+        Test percents are handled correctly for S3. S3 expected the
+        path to be unquoted once before being quoted.
+        """
+        path = "/test/%2a%2b%25/~-_^& %%"
+        expected = "/test/%2A%2B%25/~-_%5E%26%20%25%25"
+        auth = AWS4Auth("id", "secret", "us-east-1", "s3")
+        encoded = auth.amz_cano_path(path)
+        self.assertEqual(encoded, expected)
+
+
+class AWS4Auth_AmzCanonicalQuerystring_Test(unittest.TestCase):
+    def setUp(self):
+        self.auth = AWS4Auth("id", "secret", "us-east-1", "es")
+
+    def test_basic(self):
+        qs = "greet=hello"
+        encoded = self.auth.amz_cano_querystring(qs)
+        self.assertEqual(encoded, qs)
+
+    def test_multiple_params(self):
+        qs = "greet=hello&impression=wtf"
+        encoded = self.auth.amz_cano_querystring(qs)
+        self.assertEqual(encoded, qs)
+
+    def test_space(self):
+        """
+        Test space in the querystring. See post-vanilla-query-space test in the
+        downloadable amz testsuite for expected behaviour.
+        """
+        qs = "greet=hello&impression =wtf"
+        expected = "greet=hello&impression="
+        encoded = self.auth.amz_cano_querystring(qs)
+        self.assertEqual(encoded, expected)
+
+    def test_quoting(self):
+        qs = 'greet=hello&impression=!#"£$%^*()-_@~{},.<>/\\'
+        expected = "greet=hello&impression=%21%23%22%C2%A3%24%25%5E%2A%28%29-_%40~%7B%7D%2C.%3C%3E%2F%5C"
+        encoded = self.auth.amz_cano_querystring(qs)
+        self.assertEqual(encoded, expected)
+
+
+class AWS4Auth_GetCanonicalHeaders_Test(unittest.TestCase):
+    def test_headers_amz_example(self):
+        """
+        Using example from:
+        http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+        """
+        hdr_text = [
+            "host:iam.amazonaws.com",
+            "Content-type:application/x-www-form-urlencoded; charset=utf-8",
+            "My-header1:    a   b   c ",
+            "x-amz-date:20120228T030031Z",
+            'My-Header2:    "a   b   c"',
+        ]
+        headers = dict([item.split(":") for item in hdr_text])
+        req = httpx.Request("GET", "http://iam.amazonaws.com", headers=headers)
+        include = list(req.headers)
+        result = AWS4Auth.get_canonical_headers(req, include=include)
+        cano_headers, signed_headers = result
+        expected = [
+            "accept:*/*",
+            "accept-encoding:gzip, deflate",
+            "connection:keep-alive",
+            "content-type:application/x-www-form-urlencoded; charset=utf-8",
+            "host:iam.amazonaws.com",
+            "my-header1:a b c",
+            'my-header2:"a   b   c"',
+            "user-agent:python-httpx/0.12.1",
+            "x-amz-date:20120228T030031Z",
+        ]
+        expected = "\n".join(expected) + "\n"
+        self.assertEqual(cano_headers, expected)
+        expected = "accept;accept-encoding;connection;content-type;host;my-header1;my-header2;user-agent;x-amz-date"
+        self.assertEqual(signed_headers, expected)
+
+    def test_duplicate_headers(self):
+        """
+        Tests case of duplicate headers with different cased names. Uses a
+        mock Request object with regular dict to hold headers, since Requests
+        PreparedRequest dict is case-insensitive.
+        """
+        req = SimpleNamespace()
+        req.headers = {
+            "ZOO": "zoobar",
+            "FOO": "zoobar",
+            "zoo": "foobar",
+            "Content-Type": "text/plain",
+            "host": "dummy",
+        }
+        include = [x for x in req.headers if x != "Content-Type"]
+        result = AWS4Auth.get_canonical_headers(req, include=include)
+        cano_headers, signed_headers = result
+        cano_expected = "foo:zoobar\nhost:dummy\nzoo:foobar,zoobar\n"
+        signed_expected = "foo;host;zoo"
+        self.assertEqual(cano_headers, cano_expected)
+        self.assertEqual(signed_headers, signed_expected)
+
+    def test_netloc_port(self):
+        """
+        Test that change in d190dcb doesn't regress - strip port from netloc
+        before generating signature - httpx.Request always has a host header
+        """
+        req = httpx.Request("GET", "http://amazonaws.com:8443")
+        result = AWS4Auth.get_canonical_headers(req)
+        cano_hdrs, signed_hdrs = result
+        expected = "host:amazonaws.com:8443\n"
+        self.assertEqual(cano_hdrs, expected)
+
+
+class AWS4Auth_GetCanonicalRequest_Test(unittest.TestCase):
+    def test_amz1(self):
+        """
+        Using example data selected from:
+        http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+        """
+        req_text = [
+            "POST https://iam.amazonaws.com/ HTTP/1.1",
+            "Host: iam.amazonaws.com",
+            "Content-Length: 54",
+            "Content-Type: application/x-www-form-urlencoded",
+            "X-Amz-Date: 20110909T233600Z",
+            "",
+            "Action=ListUsers&Version=2010-05-08",
+        ]
+        req = request_from_text("\n".join(req_text))
+        hsh = hashlib.sha256(req_text[6].encode("utf8"))
+        req.headers["x-amz-content-sha256"] = hsh.hexdigest()
+        include_hdrs = ["host", "content-type", "x-amz-date"]
+        result = AWS4Auth.get_canonical_headers(req, include=include_hdrs)
+        cano_headers, signed_headers = result
+        expected = [
+            "POST",
+            "/",
+            "",
+            "content-type:application/x-www-form-urlencoded",
+            "host:iam.amazonaws.com",
+            "x-amz-date:20110909T233600Z",
+            "",
+            "content-type;host;x-amz-date",
+            "b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2",
+        ]
+        expected = "\n".join(expected)
+        auth = AWS4Auth("dummy", "dummy", "dummy", "host")
+        cano_req = auth.get_canonical_request(req, cano_headers, signed_headers)
+        self.assertEqual(cano_req, expected)
+
+    @unittest.skipIf(
+        amz_aws4_testsuite is None,
+        "aws4_testsuite unavailable,"
+        " download it from http://docs.aws.amazon.com/general/la"
+        "test/gr/samples/aws4_testsuite.zip",
+    )
+    def test_amz_test_suite(self):
+        for group_name in sorted(amz_aws4_testsuite.data):
+            group = amz_aws4_testsuite.data[group_name]
+            # use new 3.4 subtests if available
+            if hasattr(self, "subTest"):
+                with self.subTest(group_name=group_name, group=group):
+                    self._test_amz_test_suite_item(group_name, group)
+            else:
+                self._test_amz_test_suite_item(group_name, group)
+
+    def _test_amz_test_suite_item(self, group_name, group):
+        req = request_from_text(group[".req"])
+        if "content-length" in req.headers:
+            del req.headers["content-length"]
+        include_hdrs = list(req.headers)
+        hsh = hashlib.sha256(req.content or b"")
+        req.headers["x-amz-content-sha256"] = hsh.hexdigest()
+        result = AWS4Auth.get_canonical_headers(req, include_hdrs)
+        cano_headers, signed_headers = result
+        auth = AWS4Auth("dummy", "dummy", "dummy", "host")
+        cano_req = auth.get_canonical_request(req, cano_headers, signed_headers)
+        msg = "Group: " + group_name
+        self.assertEqual(cano_req, group[".creq"], msg=msg)
+
+
+class AWS4Auth_RequestSign_Test(unittest.TestCase):
+    def test_generate_signature(self):
+        """
+        Using example data from
+        http://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
+        """
+        secret_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+        region = "us-east-1"
+        service = "iam"
+        date = "20110909"
+        key = AWS4SigningKey(secret_key, region, service, date)
+        req_text = [
+            "POST https://iam.amazonaws.com/ HTTP/1.1",
+            "Host: iam.amazonaws.com",
+            "Content-Type: application/x-www-form-urlencoded; charset=utf-8",
+            "X-Amz-Date: 20110909T233600Z",
+            "",
+            "Action=ListUsers&Version=2010-05-08",
+        ]
+        req_text = "\n".join(req_text) + "\n"
+        req = request_from_text(req_text)
+        del req.headers["content-length"]
+        include_hdrs = list(req.headers)
+        auth = AWS4Auth("dummy", key, include_hdrs=include_hdrs)
+        hsh = hashlib.sha256(req_text[5].encode("utf8"))
+        req.headers["x-amz-content-sha256"] = hsh.hexdigest()
+        sreq = next(auth.auth_flow(req))
+        signature = sreq.headers["Authorization"].split("=")[3]
+        print(sreq.headers["Authorization"])
+        expected = "d825b8356720a0bd1d1a78d60ae2dbdaf4ed3b13575656448415487371b80376"
+        # expected = "ced6826de92d2bdeed8f846f0bf508e8559e98e4b0199114b84c541" "74deb456c"
+
+        self.assertEqual(signature, expected)
+
+    def test_generate_empty_body_signature(self):
+        """
+        Check that change in af03ce5 doesn't regress - ensure request body is
+        not altered by signing process if it is empty (i.e None).
+        """
+        auth = AWS4Auth("x", "x", "us-east-1", "s3")
+        req = httpx.Request("GET", "http://amazonaws.com", data=None)
+        sreq = next(auth.auth_flow(req))
+        signature = sreq.headers["Authorization"].split("=")[3]
+        self.assertIsNotNone(signature)
+
+    def test_regen_key_on_date_mismatch(self):
+        vals = [
+            ("20001231T235959Z", "20010101"),
+            ("20000101T010101Z", "20000102"),
+            ("19900101T010101Z", "20000101"),
+        ]
+        for amzdate, scope_date in vals:
+            req = httpx.Request("GET", "http://blah.com")
+            if "date" in req.headers:
+                del req.headers["date"]
+            req.headers["x-amz-date"] = amzdate
+            secret_key = "dummy"
+            region = "us-east-1"
+            service = "iam"
+            date = scope_date
+            key = AWS4SigningKey(secret_key, region, service, date)
+            orig_id = id(key)
+            auth = AWS4Auth("dummy", key)
+            sreq = next(auth.auth_flow(req))
+            self.assertNotEqual(id(auth.signing_key), orig_id)
+            self.assertEqual(auth.date, amzdate.split("T")[0])
+
+    @staticmethod
+    def check_auth(auth, req):
+        sreq = next(auth.auth_flow(req))
+
+    def test_date_mismatch_nosecretkey_raise(self):
+        key = AWS4SigningKey("secret_key", "region", "service", "1999010", False)
+        auth = AWS4Auth("access_id", key)
+        req = httpx.Request("GET", "http://blah.com")
+        if "date" in req.headers:
+            del req.headers["date"]
+        req.headers["x-amz-date"] = "20000101T010101Z"
+        self.assertRaises(NoSecretKeyError, self.check_auth, auth, req)
+
+    def test_sts_creds_include_security_token_header(self):
+        key = AWS4SigningKey("secret_key", "region", "service", "1999010")
+        auth = AWS4Auth("access_id", key, session_token="sessiontoken")
+        req = httpx.Request("GET", "http://blah.com")
+        sreq = next(auth.auth_flow(req))
+        self.assertIn("x-amz-security-token", sreq.headers)
+        self.assertEqual(sreq.headers.get("x-amz-security-token"), "sessiontoken")
+
+    @unittest.skipIf(
+        amz_aws4_testsuite is None,
+        "aws4_testsuite unavailable,"
+        " download it from http://docs.aws.amazon.com/general/la"
+        "test/gr/samples/aws4_testsuite.zip",
+    )
+    def test_amz_test_suite(self):
+        for group_name in sorted(amz_aws4_testsuite.data):
+            # use new 3.4 subtests if available
+            if hasattr(self, "subTest"):
+                with self.subTest(group_name=group_name):
+                    self._test_amz_test_suite_item(group_name)
+            else:
+                self._test_amz_test_suite_item(group_name)
+
+    def _test_amz_test_suite_item(self, group_name):
+        group = amz_aws4_testsuite.data[group_name]
+        req = request_from_text(group[".req"])
+        if "content-length" in req.headers:
+            del req.headers["content-length"]
+        include_hdrs = list(req.headers)
+        hsh = hashlib.sha256(req.content or b"")
+        req.headers["x-amz-content-sha256"] = hsh.hexdigest()
+        req.headers["x-amz-date"] = amz_aws4_testsuite.timestamp
+        key = AWS4SigningKey(
+            amz_aws4_testsuite.secret_key,
+            amz_aws4_testsuite.region,
+            amz_aws4_testsuite.service,
+            amz_aws4_testsuite.date,
+        )
+        auth = AWS4Auth(amz_aws4_testsuite.access_id, key, include_hdrs=include_hdrs)
+        sreq = auth(req)
+        auth_hdr = sreq.headers["Authorization"]
+        msg = "Group: " + group_name
+        self.assertEqual(auth_hdr, group[".authz"], msg=msg)
+
+
+@unittest.skipIf(
+    live_access_id is None or live_secret_key is None,
+    "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables not"
+    " set, skipping live service tests",
+)
+class AWS4Auth_LiveService_Test(unittest.TestCase):
+    """
+    Tests against live AWS services. To run these you need to provide your
+    AWS access ID and access key in the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+    environment variables respectively.
+    The AWS Support API is currently untested as it requires a premium
+    subscription, though connection parameters are supplied below if you wish
+    to try it.
+    The following services do not work with AWS auth version 4 and are excluded
+    from the tests:
+        * Simple Email Service (SES)' - AWS auth v3 only
+        * Simple Workflow Service - AWS auth v3 only
+        * Import/Export - AWS auth v2 only
+        * SimpleDB - AWS auth V2 only
+        * DevPay - AWS auth v1 only
+        * Mechanical Turk - has own signing mechanism
+    """
+
+    services = {
+        #   "AppStream": "appstream2.us-east-1.amazonaws.com/applications",
+        "Auto-Scaling": "autoscaling.us-east-1.amazonaws.com/?Action=DescribeAutoScalingInstances&Version=2011-01-01",
+        # "CloudFormation": "cloudformation.us-east-1.amazonaws.com?Action=ListStacks",
+        "CloudFront": "cloudfront.amazonaws.com/2014-11-06/distribution?MaxItems=1",
+        #  "CloudHSM": {
+        #     "method": "POST",
+        #     "req": "cloudhsm.us-east-1.amazonaws.com",
+        #     "headers": {
+        #         "X-Amz-Target": "CloudHsmFrontendService.ListAvailableZones",
+        #         "Content-Type": "application/x-amz-json-1.1",
+        #     },
+        #     "body": "{}",
+        # },
+        # "CloudSearch": "cloudsearch.us-east-1.amazonaws.com?Action=ListDomainNames&Version=2013-01-01",
+        # "CloudTrail": "cloudtrail.us-east-1.amazonaws.com?Action=DescribeTrails",
+        # "CloudWatch (monitoring)": "monitoring.us-east-1.amazonaws.com?Action=ListMetrics",
+        # "CloudWatch (logs)": {
+        #    "method": "POST",
+        #    "req": "logs.us-east-1.amazonaws.com",
+        #    "headers": {
+        #        "X-Amz-Target": "Logs_20140328.DescribeLogGroups",
+        #        "Content-Type": "application/x-amz-json-1.1",
+        #    },
+        #    "body": "{}",
+        # },
+        # "CodeDeploy": {
+        #    "method": "POST",
+        #    "req": "codedeploy.us-east-1.amazonaws.com",
+        #    "headers": {
+        #        "X-Amz-Target": "CodeDeploy_20141006.ListApplications",
+        #        "Content-Type": "application/x-amz-json-1.1",
+        #    },
+        #    "body": "{}",
+        # },
+        "Cognito Identity": {
+            "method": "POST",
+            "req": "cognito-identity.us-east-1.amazonaws.com",
+            "headers": {
+                "Content-Type": "application/json",
+                "X-Amz_Target": "AWSCognitoIdentityService.ListIdentityPools",
+            },
+            "body": json.dumps(
+                {
+                    "Operation": (
+                        "com.amazonaws.cognito.identity.model#ListIdentityPools"
+                    ),
+                    "Service": (
+                        "com.amazonaws.cognito.identity.model#AWSCognitoIdentityService"
+                    ),
+                    "Input": {"MaxResults": 1},
+                }
+            ),
+        },
+        "Cognito Sync": {
+            "method": "POST",
+            "req": "cognito-sync.us-east-1.amazonaws.com",
+            "headers": {
+                "Content-Type": "application/json",
+                "X-Amz_Target": "AWSCognitoSyncService.ListIdentityPoolUsage",
+            },
+            "body": json.dumps(
+                {
+                    "Operation": (
+                        "com.amazonaws.cognito.sync.model#ListIdentityPoolUsage"
+                    ),
+                    "Service": "com.amazonaws.cognito.sync.model#AWSCognitoSyncService",
+                    "Input": {"MaxResults": "1"},
+                }
+            ),
+        },
+        # "Config": {
+        #    "method": "POST",
+        #    "req": "config.us-east-1.amazonaws.com",
+        #    "headers": {
+        #        "X-Amz-Target": "StarlingDoveService.DescribeDeliveryChannels",
+        #        "Content-Type": "application/x-amz-json-1.1",
+        #    },
+        #    "body": "{}",
+        # },
+        # "DataPipeline": {
+        #    "req": "datapipeline.us-east-1.amazonaws.com?Action=ListPipelines",
+        #    "headers": {"X-Amz-Target": "DataPipeline.ListPipelines"},
+        #    "body": "{}",
+        # },
+        # "Direct Connect": {
+        #    "method": "POST",
+        #    "req": "directconnect.us-east-1.amazonaws.com",
+        #    "headers": {
+        #        "X-Amz-Target": "OvertureService.DescribeConnections",
+        #        "Content-Type": "application/x-amz-json-1.1",
+        #    },
+        #    "body": "{}",
+        # },
+        # "DynamoDB": {
+        #    "method": "POST",
+        #    "req": "dynamodb.us-east-1.amazonaws.com",
+        #    "headers": {
+        #        "X-Amz-Target": "DynamoDB_20111205.ListTables",
+        #        "Content-Type": "application/x-amz-json-1.0",
+        #    },
+        #    "body": "{}",
+        # },
+        "Elastic Beanstalk": "elasticbeanstalk.us-east-1.amazonaws.com/?Action=ListAvailableSolutionStacks&Version=2010-12-01",
+        "ElastiCache": "elasticache.us-east-1.amazonaws.com/?Action=DescribeCacheClusters&Version=2014-07-15",
+        "EC2": "ec2.us-east-1.amazonaws.com/?Action=DescribeRegions&Version=2014-06-15",
+        "EC2 Container Service": (
+            "ecs.us-east-1.amazonaws.com/?Action=ListClusters&Version=2014-11-13"
+        ),
+        "Elastic Load Balancing": "elasticloadbalancing.us-east-1.amazonaws.com/?Action=DescribeLoadBalancers&Version=2012-06-01",
+        "Elastic MapReduce": "elasticmapreduce.us-east-1.amazonaws.com/?Action=ListClusters&Version=2009-03-31",
+        "Elastic Transcoder": (
+            "elastictranscoder.us-east-1.amazonaws.com/2012-09-25/pipelines"
+        ),
+        "Glacier": {
+            "req": "glacier.us-east-1.amazonaws.com/-/vaults",
+            "headers": {"X-Amz-Glacier-Version": "2012-06-01"},
+        },
+        "Identity and Access Management (IAM)": (
+            "iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08"
+        ),
+        # "Key Management Service": {
+        #    "method": "POST",
+        #    "req": "kms.us-east-1.amazonaws.com",
+        #    "headers": {
+        #        "Content-Type": "application/x-amz-json-1.1",
+        #        "X-Amz-Target": "TrentService.ListKeys",
+        #    },
+        #    "body": "{}",
+        # },
+        # "Kinesis": {
+        #     "method": "POST",
+        #     "req": "kinesis.us-east-1.amazonaws.com",
+        #     "headers": {
+        #         "Content-Type": "application/x-amz-json-1.1",
+        #         "X-Amz-Target": "Kinesis_20131202.ListStreams",
+        #     },
+        #     "body": "{}",
+        # },
+        "Lambda": "lambda.us-east-1.amazonaws.com/2014-11-13/functions/",
+        # "Opsworks": {
+        #    "method": "POST",
+        #    "req": "opsworks.us-east-1.amazonaws.com",
+        #    "headers": {
+        #        "Content-Type": "application/x-amz-json-1.1",
+        #        "X-Amz-Target": "OpsWorks_20130218.DescribeStacks",
+        #    },
+        #    "body": "{}",
+        # },
+        "Redshift": "redshift.us-east-1.amazonaws.com/?Action=DescribeClusters&Version=2012-12-01",
+        "Relational Database Service (RDS)": (
+            "rds.us-east-1.amazonaws.com/?Action=DescribeDBInstances&Version=2012-09-17"
+        ),
+        "Route 53": "route53.amazonaws.com/2013-04-01/hostedzone",
+        # "Simple Storage Service (S3)": "s3.amazonaws.com",
+        "Simple Notification Service (SNS)": (
+            "sns.us-east-1.amazonaws.com/?Action=ListTopics&Version=2010-03-31"
+        ),
+        "Simple Queue Service (SQS)": "sqs.us-east-1.amazonaws.com/?Action=ListQueues",
+        # "Storage Gateway": {
+        #    "method": "POST",
+        #    "req": "storagegateway.us-east-1.amazonaws.com",
+        #    "headers": {
+        #        "Content-Type": "application/x-amz-json-1.1",
+        #        "X-Amz-Target": "StorageGateway_20120630.ListGateways",
+        #    },
+        #    "body": "{}",
+        # },
+        "Security Token Service": (
+            "sts.amazonaws.com/?Action=GetSessionToken&Version=2011-06-15"
+        ),
+        # 'Support': {
+        #     'method': 'POST',
+        #     'req': 'support.us-east-1.amazonaws.com',
+        #     'headers': {'Content-Type': 'application/x-amz-json-1.0',
+        #                 'X-Amz-Target': 'Support_20130415.DescribeServices'},
+        #     'body': '{}'},
+    }
+
+    def test_live_services(self):
+        for service_name in sorted(self.services):
+            params = self.services[service_name]
+            # use new 3.4 subtests if available
+            if hasattr(self, "subTest"):
+                with self.subTest(service_name=service_name, params=params):
+                    self._test_live_service(service_name, params)
+            else:
+                self._test_live_service(service_name, params)
+
+    def _test_live_service(self, service_name, params):
+        if isinstance(params, dict):
+            method = params.get("method", "GET")
+            path_qs = params["req"]
+            headers = params.get("headers", {})
+            body = params.get("body", "")
+        else:
+            method = "GET"
+            path_qs = params
+            headers = {}
+            body = ""
+        service = path_qs.split(".")[0]
+        url = "https://" + path_qs
+        region = "us-east-1"
+        auth = AWS4Auth(live_access_id, live_secret_key, region, service)
+        print(f"connecting to {url}")
+        response = httpx.request(method, url, auth=auth, data=body, headers=headers)
+        self.assertEqual(response.status_code, httpx.codes.OK)
+
+    def test_mobileanalytics(self):
+        url = "https://mobileanalytics.us-east-1.amazonaws.com/2014-06-05/events"
+        service = "mobileanalytics"
+        region = "us-east-1"
+        dt = datetime.datetime.utcnow()
+        date = dt.strftime("%Y%m%d")
+        sig_key = AWS4SigningKey(live_secret_key, region, service, date)
+        auth = AWS4Auth(live_access_id, sig_key)
+        headers = {
+            "Content-Type": "application/json",
+            "X-Amz-Date": dt.strftime("%Y%m%dT%H%M%SZ"),
+            "X-Amz-Client-Context": json.dumps(
+                {
+                    "client": {"client_id": "a", "app_title": "a"},
+                    "custom": {},
+                    "env": {"platform": "a"},
+                    "services": {},
+                }
+            ),
+        }
+        body = json.dumps(
+            {
+                "events": [
+                    {
+                        "eventType": "a",
+                        "timestamp": dt.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+                        "session": {},
+                    }
+                ]
+            }
+        )
+        response = httpx.post(url, auth=auth, headers=headers, data=body)
+        self.assertEqual(response.status_code, httpx.codes.OK)
+
+
+if __name__ == "__main__":
+    #     unittest.main(verbosity=2, defaultTest='AWS4Auth_Instantiate_Test')
+    #     unittest.main(verbosity=2, defaultTest='AWS4Auth_RequestSign_Test')
+    unittest.main(verbosity=2)


### PR DESCRIPTION
… due to api changes in AWS since request_aws4auth was updated.  I am still working on updating the live tests. And trying to get access to the AWS signing test suite which seems to have been moved, or taken down.  I have not used pytest before and the code in requests-aws4auth which this is based on uses unittest.    I wanted to get you to look at this so if we want to make changes to make it more consistent you might be able to point me in the correct direction. 

One specific area I could use help with is the live tests basically run through a bunch of tests cases in one test.  the unittest framework will run all of them even if some fail pytest seems to stop on the first one.  I am wondering if there is a way to change that behavior ( or a different way of parameterizing the test to get that result.). 

Also if there are other changes you would like me to make aka style etc. let me know.  Again this is largely a port of the requests-aws4auth over.      

Please feel free to let me know what you think.  