### PR TITLE
Allow to provide a custom client on some auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow to provide an `httpx.Client` instance for `*AuthorizationCode` flows (even `PKCE`), `*ClientCredentials` and `*ResourceOwnerPasswordCredentials` flows.
 
 ## [0.4.0] - 2020-08-07
 ### Changed

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ with httpx.Client() as client:
 | `code_field_name`       | Field name containing the code. | Optional | code |
 | `username`              | User name in case basic authentication should be used to retrieve token. | Optional |  |
 | `password`              | User password in case basic authentication should be used to retrieve token. | Optional |  |
+| `client`                | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as query parameter in the authorization URL and as body parameters in the token URL.        
 
@@ -133,6 +134,7 @@ with httpx.Client() as client:
 | `failure_display_time`  | In case received token is not valid, this is the maximum amount of milliseconds the failure page will be displayed in your browser. | Optional | 5000 |
 | `header_name`           | Name of the header field used to send token. | Optional | Authorization |
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
+| `client`                | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as query parameter in the authorization URL.        
 
@@ -172,6 +174,7 @@ with httpx.Client() as client:
 | `response_type`         | Value of the response_type query parameter if not already provided in authorization URL. | Optional | code |
 | `token_field_name`      | Field name containing the token. | Optional | access_token |
 | `code_field_name`       | Field name containing the code. | Optional | code |
+| `client`                | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as query parameter in the authorization URL and as body parameters in the token URL.        
 
@@ -224,6 +227,7 @@ with httpx.Client() as client:
 | `failure_display_time`  | In case received token is not valid, this is the maximum amount of milliseconds the failure page will be displayed in your browser. | Optional | 5000 |
 | `header_name`           | Name of the header field used to send token. | Optional | Authorization |
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
+| `client`                | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as query parameter in the authorization URL and as body parameters in the token URL.        
 
@@ -260,6 +264,7 @@ with httpx.Client() as client:
 | `header_value`     | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `scope`            | Scope parameter sent to token URL as body. Can also be a list of scopes. | Optional |  |
 | `token_field_name` | Field name containing the token.             | Optional  | access_token  |
+| `client`           | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as body parameter in the token URL.
 
@@ -289,6 +294,7 @@ with httpx.Client() as client:
 | `header_value`     | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `scope`            | Scope parameter sent to token URL as body. Can also be a list of scopes. | Optional |  |
 | `token_field_name` | Field name containing the token.             | Optional  | access_token  |
+| `client`           | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as body parameter in the token URL.
 
@@ -327,6 +333,7 @@ with httpx.Client() as client:
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `scope`                 | Scope parameter sent in query. Can also be a list of scopes. | Optional | openid |
 | `token_field_name`      | Field name containing the token. | Optional | access_token |
+| `client`                | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as query parameter in the token URL.        
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
             # Used to generate test tokens
             "pyjwt==1.*",
             # Used to mock httpx
-            "pytest_httpx==0.6.*",
+            "pytest_httpx==0.7.*",
             # Used to check coverage
             "pytest-cov==2.*",
         ]

--- a/tests/auth_helper.py
+++ b/tests/auth_helper.py
@@ -5,7 +5,7 @@ from pytest_httpx import HTTPXMock
 # TODO Remove
 def get_header(httpx_mock: HTTPXMock, auth: httpx.Auth) -> dict:
     # Mock a dummy response
-    httpx_mock.add_response()
+    httpx_mock.add_response(url="http://authorized_only", method="GET")
     # Send a request to this dummy URL with authentication
     response = httpx.get("http://authorized_only", auth=auth)
     # Return headers received on this dummy URL

--- a/tests/test_oauth2_authorization_code.py
+++ b/tests/test_oauth2_authorization_code.py
@@ -6,6 +6,40 @@ import httpx_auth
 from httpx_auth.testing import BrowserMock, browser_mock, token_cache
 
 
+def test_oauth2_authorization_code_flow_uses_provided_client(
+    token_cache, httpx_mock: HTTPXMock, browser_mock: BrowserMock
+):
+    client = httpx.Client(headers={"x-test": "Test value"})
+    auth = httpx_auth.OAuth2AuthorizationCode(
+        "http://provide_code", "http://provide_access_token", client=client
+    )
+    tab = browser_mock.add_response(
+        opened_url="http://provide_code?response_type=code&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA",
+        match_headers={"x-test": "Test value"},
+    )
+    httpx_mock.add_response(
+        match_headers={"Authorization": "Bearer 2YotnFZFEjr1zCsicMWpAA"}
+    )
+    # Send a request to this dummy URL with authentication
+    httpx.get("http://authorized_only", auth=auth)
+    tab.assert_success(
+        "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+
+
 def test_oauth2_authorization_code_flow_get_code_is_sent_in_authorization_header_by_default(
     token_cache, httpx_mock: HTTPXMock, browser_mock: BrowserMock
 ):

--- a/tests/test_oauth2_authorization_code_pkce.py
+++ b/tests/test_oauth2_authorization_code_pkce.py
@@ -7,6 +7,40 @@ from tests.auth_helper import get_header
 from httpx_auth.testing import BrowserMock, browser_mock, token_cache
 
 
+def test_oauth2_pkce_flow_uses_provided_client(
+    token_cache, httpx_mock: HTTPXMock, monkeypatch, browser_mock: BrowserMock
+):
+    client = httpx.Client(headers={"x-test": "Test value"})
+    monkeypatch.setattr(httpx_auth.authentication.os, "urandom", lambda x: b"1" * 63)
+    auth = httpx_auth.OAuth2AuthorizationCodePKCE(
+        "http://provide_code", "http://provide_access_token", client=client
+    )
+    tab = browser_mock.add_response(
+        opened_url="http://provide_code?response_type=code&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&code_challenge=5C_ph_KZ3DstYUc965SiqmKAA-ShvKF4Ut7daKd3fjc&code_challenge_method=S256",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"code_verifier=MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEx&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA",
+        match_headers={"x-test": "Test value"},
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    tab.assert_success(
+        "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+
+
 def test_oauth2_pkce_flow_get_code_is_sent_in_authorization_header_by_default(
     token_cache, httpx_mock: HTTPXMock, monkeypatch, browser_mock: BrowserMock
 ):

--- a/tests/test_oauth2_authorization_code_pkce_okta.py
+++ b/tests/test_oauth2_authorization_code_pkce_okta.py
@@ -7,6 +7,42 @@ from tests.auth_helper import get_header
 from httpx_auth.testing import BrowserMock, browser_mock, token_cache
 
 
+def test_oauth2_pkce_flow_uses_provided_client(
+    token_cache, httpx_mock: HTTPXMock, monkeypatch, browser_mock: BrowserMock
+):
+    client = httpx.Client(headers={"x-test": "Test value"})
+    monkeypatch.setattr(httpx_auth.authentication.os, "urandom", lambda x: b"1" * 63)
+    auth = httpx_auth.OktaAuthorizationCodePKCE(
+        "testserver.okta-emea.com",
+        "54239d18-c68c-4c47-8bdd-ce71ea1d50cd",
+        client=client,
+    )
+    tab = browser_mock.add_response(
+        opened_url="https://testserver.okta-emea.com/oauth2/default/v1/authorize?client_id=54239d18-c68c-4c47-8bdd-ce71ea1d50cd&scope=openid&response_type=code&state=5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&code_challenge=5C_ph_KZ3DstYUc965SiqmKAA-ShvKF4Ut7daKd3fjc&code_challenge_method=S256",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"code_verifier=MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEx&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&client_id=54239d18-c68c-4c47-8bdd-ce71ea1d50cd&scope=openid&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA",
+        match_headers={"x-test": "Test value"},
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    tab.assert_success(
+        "You are now authenticated on 5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b. You may close this tab."
+    )
+
+
 def test_oauth2_pkce_flow_get_code_is_sent_in_authorization_header_by_default(
     token_cache, httpx_mock: HTTPXMock, monkeypatch, browser_mock: BrowserMock
 ):

--- a/tests/test_oauth2_client_credential.py
+++ b/tests/test_oauth2_client_credential.py
@@ -7,6 +7,34 @@ from tests.auth_helper import get_header
 from httpx_auth.testing import token_cache
 
 
+def test_oauth2_client_credentials_flow_uses_provided_client(
+    token_cache, httpx_mock: HTTPXMock
+):
+    client = httpx.Client(headers={"x-test": "Test value"})
+    auth = httpx_auth.OAuth2ClientCredentials(
+        "http://provide_access_token",
+        client_id="test_user",
+        client_secret="test_pwd",
+        client=client,
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_headers={"x-test": "Test value"},
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
 def test_oauth2_client_credentials_flow_token_is_sent_in_authorization_header_by_default(
     token_cache, httpx_mock: HTTPXMock
 ):

--- a/tests/test_oauth2_client_credential_okta.py
+++ b/tests/test_oauth2_client_credential_okta.py
@@ -1,8 +1,34 @@
 from pytest_httpx import HTTPXMock
+import httpx
 
 import httpx_auth
 from tests.auth_helper import get_header
 from httpx_auth.testing import token_cache
+
+
+def test_okta_client_credentials_flow_uses_provided_client(
+    token_cache, httpx_mock: HTTPXMock
+):
+    client = httpx.Client(headers={"x-test": "Test value"})
+    auth = httpx_auth.OktaClientCredentials(
+        "test_okta", client_id="test_user", client_secret="test_pwd", client=client
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://test_okta/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_headers={"x-test": "Test value"},
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
 
 
 def test_okta_client_credentials_flow_token_is_sent_in_authorization_header_by_default(

--- a/tests/test_oauth2_resource_owner_password.py
+++ b/tests/test_oauth2_resource_owner_password.py
@@ -7,6 +7,35 @@ from tests.auth_helper import get_header
 from httpx_auth.testing import token_cache
 
 
+def test_oauth2_password_credentials_flow_uses_provided_client(
+    token_cache, httpx_mock: HTTPXMock
+):
+    client = httpx.Client(headers={"x-test": "Test value"})
+    auth = httpx_auth.OAuth2ResourceOwnerPasswordCredentials(
+        "http://provide_access_token",
+        username="test_user",
+        password="test_pwd",
+        client=client,
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"grant_type=password&username=test_user&password=test_pwd",
+        match_headers={"x-test": "Test value"},
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
 def test_oauth2_password_credentials_flow_token_is_sent_in_authorization_header_by_default(
     token_cache, httpx_mock: HTTPXMock
 ):


### PR DESCRIPTION
To be able to provide extra information for underlying POST queries. Such as proxy