### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2020-09-22
+### Changed
+- Requires [`httpx`](https://www.python-httpx.org)==0.15.*
+
 ## [0.5.1] - 2020-08-31
 ### Fixed
 - `AWSAuth` authentication class now handles empty path. Thanks to [`Michael E. Martinka`](https://github.com/martinka). This class is still considered as under development and subject to breaking changes without notice.
@@ -54,7 +58,8 @@ Note that a few changes were made:
 ### Added
 - Placeholder for port of requests_auth to httpx
 
-[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/Colin-b/httpx_auth/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Colin-b/httpx_auth/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Colin-b/httpx_auth/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Colin-b/httpx_auth/compare/v0.3.0...v0.4.0

--- a/httpx_auth/version.py
+++ b/httpx_auth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/setup.py
+++ b/setup.py
@@ -35,14 +35,14 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         # Used for Base Authentication and to communicate with OAuth2 servers
-        "httpx==0.14.*"
+        "httpx==0.15.*"
     ],
     extras_require={
         "testing": [
             # Used to generate test tokens
             "pyjwt==1.*",
             # Used to mock httpx
-            "pytest_httpx==0.8.*",
+            "pytest_httpx==0.9.*",
             # Used to check coverage
             "pytest-cov==2.*",
         ]


### PR DESCRIPTION
### Changed
- Requires [`httpx`](https://www.python-httpx.org)==0.15.*
