### PR TITLE
Release 0.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9-dev"
+  - "3.9"
 install:
   - pip install .[testing]
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - OAuth2 token will now be considered as expired 30 seconds before actual expiry. To ensure it is still valid when received by the actual server.
 
+### Added
+- `httpx_auth.OAuth2ResourceOwnerPasswordCredentials` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
+
 ## [0.7.0] - 2020-10-06
 ### Added
 - Explicit support for Python 3.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `get_token` cache method now requires `on_missing_token` function args to be provided as kwargs instead of args.
 - `get_token` cache method now requires `on_missing_token` parameter to be provided as a non positional argument.
+- `get_token` cache method now expose `early_expiry` parameter, defaulting to 30 seconds.
+
+### Fixed
+- OAuth2 token will now be considered as expired 30 seconds before actual expiry. To ensure it is still valid when received by the actual server.
 
 ## [0.7.0] - 2020-10-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `httpx_auth.OktaAuthorizationCode` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
 - `httpx_auth.OAuth2AuthorizationCodePKCE` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
 - `httpx_auth.OktaAuthorizationCodePKCE` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
+- `httpx_auth.OAuth2Implicit` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
+- `httpx_auth.AzureActiveDirectoryImplicit` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
+- `httpx_auth.AzureActiveDirectoryImplicitIdToken` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
+- `httpx_auth.OktaImplicit` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
+- `httpx_auth.OktaImplicitIdToken` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
 
 ## [0.7.0] - 2020-10-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Do not expose `httpx_auth.oauth2_tokens.decode_base64` function anymore as it supposed to be used internally only.
+- Do not expose `add_bearer_token` token cache method anymore as it supposed to be used internally only.
+- Do not expose `add_access_token` token cache method anymore as it supposed to be used internally only.
 
 ## [0.7.0] - 2020-10-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.7.0] - 2020-10-06
 ### Added
 - Explicit support for Python 3.9
 - Document `httpx_auth.AWS4Auth` authentication class.
@@ -65,7 +67,8 @@ Note that a few changes were made:
 ### Added
 - Placeholder for port of requests_auth to httpx
 
-[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/Colin-b/httpx_auth/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Colin-b/httpx_auth/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Colin-b/httpx_auth/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Colin-b/httpx_auth/compare/v0.4.0...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `httpx_auth.OktaClientCredentials` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
 - `httpx_auth.OAuth2AuthorizationCode` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
 - `httpx_auth.OktaAuthorizationCode` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
+- `httpx_auth.OAuth2AuthorizationCodePKCE` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
+- `httpx_auth.OktaAuthorizationCodePKCE` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
 
 ## [0.7.0] - 2020-10-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.0] - 2020-11-15
 ### Removed
 - Do not expose `httpx_auth.oauth2_tokens.decode_base64` function anymore as it supposed to be used internally only.
 - Do not expose `add_bearer_token` token cache method anymore as it supposed to be used internally only.
@@ -93,7 +95,8 @@ Note that a few changes were made:
 ### Added
 - Placeholder for port of requests_auth to httpx
 
-[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/Colin-b/httpx_auth/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Colin-b/httpx_auth/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Colin-b/httpx_auth/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Colin-b/httpx_auth/compare/v0.5.0...v0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `httpx_auth.OAuth2ResourceOwnerPasswordCredentials` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
+- `httpx_auth.OAuth2ClientCredentials` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
+- `httpx_auth.OktaClientCredentials` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
 
 ## [0.7.0] - 2020-10-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not expose `add_bearer_token` token cache method anymore as it supposed to be used internally only.
 - Do not expose `add_access_token` token cache method anymore as it supposed to be used internally only.
 
+### Changed
+- `get_token` cache method now requires `on_missing_token` function args to be provided as kwargs instead of args.
+- `get_token` cache method now requires `on_missing_token` parameter to be provided as a non positional argument.
+
 ## [0.7.0] - 2020-10-06
 ### Added
 - Explicit support for Python 3.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `httpx_auth.OAuth2ResourceOwnerPasswordCredentials` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
 - `httpx_auth.OAuth2ClientCredentials` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
 - `httpx_auth.OktaClientCredentials` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
+- `httpx_auth.OAuth2AuthorizationCode` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
+- `httpx_auth.OktaAuthorizationCode` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
 
 ## [0.7.0] - 2020-10-06
 ### Added

--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ with httpx.Client() as client:
 | `authorization_url`     | OAuth 2 authorization URL. | Mandatory |               |
 | `response_type`         | Value of the response_type query parameter if not already provided in authorization URL. | Optional | token |
 | `token_field_name`      | Field name containing the token. | Optional | id_token if response_type is id_token, otherwise access_token |
+| `early_expiry`          | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
 | `redirect_uri_endpoint` | Custom endpoint that will be used as redirect_uri the following way: http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. | Optional | ''             |
 | `redirect_uri_port`     | The port on which the server listening for the OAuth 2 token will be started. | Optional | 5000 |
 | `timeout`               | Maximum amount of seconds to wait for a token to be received once requested. | Optional | 60 |
@@ -416,6 +417,7 @@ You can retrieve Microsoft Azure Active Directory application information thanks
 | `client_id`             | Microsoft Application Identifier (formatted as an Universal Unique Identifier). | Mandatory |               |
 | `response_type`         | Value of the response_type query parameter if not already provided in authorization URL. | Optional | token |
 | `token_field_name`      | Field name containing the token. | Optional | access_token |
+| `early_expiry`          | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
 | `nonce`                 | Refer to [OpenID ID Token specifications][3] for more details | Optional | Newly generated Universal Unique Identifier. |
 | `redirect_uri_endpoint` | Custom endpoint that will be used as redirect_uri the following way: http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. | Optional | ''             |
 | `redirect_uri_port`     | The port on which the server listening for the OAuth 2 token will be started. | Optional | 5000 |
@@ -459,6 +461,7 @@ You can retrieve Microsoft Azure Active Directory application information thanks
 | `client_id`             | Microsoft Application Identifier (formatted as an Universal Unique Identifier). | Mandatory |               |
 | `response_type`         | Value of the response_type query parameter if not already provided in authorization URL. | Optional | id_token |
 | `token_field_name`      | Field name containing the token. | Optional | id_token |
+| `early_expiry`          | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
 | `nonce`                 | Refer to [OpenID ID Token specifications][3] for more details | Optional | Newly generated Universal Unique Identifier. |
 | `redirect_uri_endpoint` | Custom endpoint that will be used as redirect_uri the following way: http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. | Optional | ''             |
 | `redirect_uri_port`     | The port on which the server listening for the OAuth 2 token will be started. | Optional | 5000 |
@@ -500,6 +503,7 @@ with httpx.Client() as client:
 | `client_id`             | Okta Application Identifier (formatted as an Universal Unique Identifier). | Mandatory |               |
 | `response_type`         | Value of the response_type query parameter if not already provided in authorization URL. | Optional | token |
 | `token_field_name`      | Field name containing the token. | Optional | access_token |
+| `early_expiry`          | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
 | `nonce`                 | Refer to [OpenID ID Token specifications][3] for more details. | Optional | Newly generated Universal Unique Identifier. |
 | `scope`                 | Scope parameter sent in query. Can also be a list of scopes. | Optional | ['openid', 'profile', 'email'] |
 | `authorization_server`  | Okta authorization server. | Optional | 'default' |
@@ -543,6 +547,7 @@ with httpx.Client() as client:
 | `client_id`             | Okta Application Identifier (formatted as an Universal Unique Identifier). | Mandatory |               |
 | `response_type`         | Value of the response_type query parameter if not already provided in authorization URL. | Optional | id_token |
 | `token_field_name`      | Field name containing the token. | Optional | id_token |
+| `early_expiry`          | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
 | `nonce`                 | Refer to [OpenID ID Token specifications][3] for more details. | Optional | Newly generated Universal Unique Identifier. |
 | `scope`                 | Scope parameter sent in query. Can also be a list of scopes. | Optional | ['openid', 'profile', 'email'] |
 | `authorization_server`  | Okta authorization server. | Optional | 'default' |

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ with httpx.Client() as client:
 | `header_value`     | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `scope`            | Scope parameter sent to token URL as body. Can also be a list of scopes. | Optional |  |
 | `token_field_name` | Field name containing the token.             | Optional  | access_token  |
+| `early_expiry`     | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
 | `client`           | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as body parameter in the token URL.
@@ -335,6 +336,7 @@ with httpx.Client() as client:
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `scope`                 | Scope parameter sent in query. Can also be a list of scopes. | Optional | openid |
 | `token_field_name`      | Field name containing the token. | Optional | access_token |
+| `early_expiry`          | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
 | `client`                | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as query parameter in the token URL.        

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ with httpx.Client() as client:
 | `header_value`     | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `scope`            | Scope parameter sent to token URL as body. Can also be a list of scopes. | Optional |  |
 | `token_field_name` | Field name containing the token.             | Optional  | access_token  |
+| `early_expiry`     | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
 | `client`           | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
 Any other parameter will be put as body parameter in the token URL.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ with httpx.Client() as client:
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `response_type`         | Value of the response_type query parameter if not already provided in authorization URL. | Optional | code |
 | `token_field_name`      | Field name containing the token. | Optional | access_token |
+| `early_expiry`          | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
 | `code_field_name`       | Field name containing the code. | Optional | code |
 | `client`                | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
 
@@ -219,6 +220,7 @@ with httpx.Client() as client:
 | `client_id`             | Okta Application Identifier (formatted as an Universal Unique Identifier). | Mandatory |               |
 | `response_type`         | Value of the response_type query parameter if not already provided in authorization URL. | Optional | code |
 | `token_field_name`      | Field name containing the token. | Optional | access_token |
+| `early_expiry`          | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
 | `code_field_name`      | Field name containing the code. | Optional | code |
 | `nonce`                 | Refer to [OpenID ID Token specifications][3] for more details. | Optional | Newly generated Universal Unique Identifier. |
 | `scope`                 | Scope parameter sent in query. Can also be a list of scopes. | Optional | openid |

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ with httpx.Client() as client:
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `response_type`         | Value of the response_type query parameter if not already provided in authorization URL. | Optional | code |
 | `token_field_name`      | Field name containing the token. | Optional | access_token |
+| `early_expiry`          | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
 | `code_field_name`       | Field name containing the code. | Optional | code |
 | `username`              | User name in case basic authentication should be used to retrieve token. | Optional |  |
 | `password`              | User password in case basic authentication should be used to retrieve token. | Optional |  |
@@ -125,6 +126,7 @@ with httpx.Client() as client:
 | `client_id`             | Okta Application Identifier (formatted as an Universal Unique Identifier). | Mandatory |               |
 | `response_type`         | Value of the response_type query parameter if not already provided in authorization URL. | Optional | token |
 | `token_field_name`      | Field name containing the token. | Optional | access_token |
+| `early_expiry`          | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
 | `nonce`                 | Refer to [OpenID ID Token specifications][3] for more details. | Optional | Newly generated Universal Unique Identifier. |
 | `scope`                 | Scope parameter sent in query. Can also be a list of scopes. | Optional | openid |
 | `authorization_server`  | Okta authorization server. | Optional | 'default' |

--- a/httpx_auth/authentication.py
+++ b/httpx_auth/authentication.py
@@ -649,6 +649,9 @@ class OAuth2Implicit(httpx.Auth, SupportMultiAuth, BrowserAuth):
         token by default.
         :param token_field_name: Name of the expected field containing the token.
         id_token by default if response_type is id_token, else access_token.
+        :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
+        Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
+        reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
         http://localhost:<redirect_uri_port>/<redirect_uri_endpoint>. Default value is to redirect on / (root).
         :param redirect_uri_port: The port on which the server listening for the OAuth 2 token will be started.
@@ -699,7 +702,7 @@ class OAuth2Implicit(httpx.Auth, SupportMultiAuth, BrowserAuth):
                 "id_token" if "id_token" == response_type else "access_token"
             )
 
-        self.early_expiry = 30.0
+        self.early_expiry = float(kwargs.pop("early_expiry", None) or 30.0)
 
         authorization_url_without_nonce = _add_parameters(
             self.authorization_url, kwargs
@@ -750,6 +753,9 @@ class AzureActiveDirectoryImplicit(OAuth2Implicit):
         token by default.
         :param token_field_name: Name of the expected field containing the token.
         access_token by default.
+        :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
+        Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
+        reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param nonce: Refer to http://openid.net/specs/openid-connect-core-1_0.html#IDToken for more details
         (formatted as an Universal Unique Identifier - UUID). Use a newly generated UUID by default.
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
@@ -797,6 +803,9 @@ class AzureActiveDirectoryImplicitIdToken(OAuth2Implicit):
         id_token by default.
         :param token_field_name: Name of the expected field containing the token.
         id_token by default.
+        :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
+        Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
+        reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param nonce: Refer to http://openid.net/specs/openid-connect-core-1_0.html#IDToken for more details
         (formatted as an Universal Unique Identifier - UUID). Use a newly generated UUID by default.
         :param redirect_uri_endpoint: Custom endpoint that will be used as redirect_uri the following way:
@@ -847,6 +856,9 @@ class OktaImplicit(OAuth2Implicit):
         token by default.
         :param token_field_name: Name of the expected field containing the token.
         access_token by default.
+        :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
+        Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
+        reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param nonce: Refer to http://openid.net/specs/openid-connect-core-1_0.html#IDToken for more details
         (formatted as an Universal Unique Identifier - UUID). Use a newly generated UUID by default.
         :param authorization_server: Okta authorization server.
@@ -900,6 +912,9 @@ class OktaImplicitIdToken(OAuth2Implicit):
         id_token by default.
         :param token_field_name: Name of the expected field containing the token.
         id_token by default.
+        :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
+        Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
+        reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param nonce: Refer to http://openid.net/specs/openid-connect-core-1_0.html#IDToken for more details
         (formatted as an Universal Unique Identifier - UUID). Use a newly generated UUID by default.
         :param authorization_server: Okta authorization server

--- a/httpx_auth/authentication.py
+++ b/httpx_auth/authentication.py
@@ -236,6 +236,9 @@ class OAuth2ClientCredentials(httpx.Auth, SupportMultiAuth):
         Token will be sent as "Bearer {token}" by default.
         :param scope: Scope parameter sent to token URL as body. Can also be a list of scopes. Not sent by default.
         :param token_field_name: Field name containing the token. access_token by default.
+        :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
+        Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
+        reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param client: httpx.Client instance that will be used to request the token.
         Use it to provide a custom proxying rule for instance.
         :param kwargs: all additional authorization parameters that should be put as query parameter in the token URL.
@@ -256,7 +259,7 @@ class OAuth2ClientCredentials(httpx.Auth, SupportMultiAuth):
             raise Exception("header_value parameter must contains {token}.")
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
-        self.early_expiry = 30.0
+        self.early_expiry = float(kwargs.pop("early_expiry", None) or 30.0)
 
         # Time is expressed in seconds
         self.timeout = int(kwargs.pop("timeout", None) or 60)
@@ -1067,6 +1070,9 @@ class OktaClientCredentials(OAuth2ClientCredentials):
         :param scope: Scope parameter sent to token URL as body. Can also be a list of scopes.
         Request 'openid' by default.
         :param token_field_name: Field name containing the token. access_token by default.
+        :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
+        Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
+        reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param client: httpx.Client instance that will be used to request the token.
         Use it to provide a custom proxying rule for instance.
         :param kwargs: all additional authorization parameters that should be put as query parameter in the token URL.

--- a/httpx_auth/authentication.py
+++ b/httpx_auth/authentication.py
@@ -334,6 +334,9 @@ class OAuth2AuthorizationCode(httpx.Auth, SupportMultiAuth, BrowserAuth):
         :param response_type: Value of the response_type query parameter if not already provided in authorization URL.
         code by default.
         :param token_field_name: Field name containing the token. access_token by default.
+        :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
+        Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
+        reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param code_field_name: Field name containing the code. code by default.
         :param username: User name in case basic authentication should be used to retrieve token.
         :param password: User password in case basic authentication should be used to retrieve token.
@@ -362,7 +365,7 @@ class OAuth2AuthorizationCode(httpx.Auth, SupportMultiAuth, BrowserAuth):
             raise Exception("header_value parameter must contains {token}.")
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
-        self.early_expiry = 30.0
+        self.early_expiry = float(kwargs.pop("early_expiry", None) or 30.0)
 
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
@@ -949,6 +952,9 @@ class OktaAuthorizationCode(OAuth2AuthorizationCode):
         token by default.
         :param token_field_name: Name of the expected field containing the token.
         access_token by default.
+        :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
+        Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
+        reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param nonce: Refer to http://openid.net/specs/openid-connect-core-1_0.html#IDToken for more details
         (formatted as an Universal Unique Identifier - UUID). Use a newly generated UUID by default.
         :param authorization_server: Okta authorization server

--- a/httpx_auth/authentication.py
+++ b/httpx_auth/authentication.py
@@ -480,6 +480,9 @@ class OAuth2AuthorizationCodePKCE(httpx.Auth, SupportMultiAuth, BrowserAuth):
         :param response_type: Value of the response_type query parameter if not already provided in authorization URL.
         code by default.
         :param token_field_name: Field name containing the token. access_token by default.
+        :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
+        Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
+        reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param code_field_name: Field name containing the code. code by default.
         :param client: httpx.Client instance that will be used to request the token.
         Use it to provide a custom proxying rule for instance.
@@ -509,7 +512,7 @@ class OAuth2AuthorizationCodePKCE(httpx.Auth, SupportMultiAuth, BrowserAuth):
             raise Exception("header_value parameter must contains {token}.")
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
-        self.early_expiry = 30.0
+        self.early_expiry = float(kwargs.pop("early_expiry", None) or 30.0)
 
         # As described in https://tools.ietf.org/html/rfc6749#section-4.1.2
         code_field_name = kwargs.pop("code_field_name", "code")
@@ -1010,6 +1013,9 @@ class OktaAuthorizationCodePKCE(OAuth2AuthorizationCodePKCE):
         code by default.
         :param token_field_name: Name of the expected field containing the token.
         access_token by default.
+        :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
+        Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
+        reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param code_field_name: Field name containing the code. code by default.
         :param nonce: Refer to http://openid.net/specs/openid-connect-core-1_0.html#IDToken for more details
         (formatted as an Universal Unique Identifier - UUID). Use a newly generated UUID by default.

--- a/httpx_auth/authentication.py
+++ b/httpx_auth/authentication.py
@@ -197,7 +197,7 @@ class OAuth2ResourceOwnerPasswordCredentials(httpx.Auth, SupportMultiAuth):
         request.headers[self.header_name] = self.header_value.format(token=token)
         yield request
 
-    def request_new_token(self):
+    def request_new_token(self) -> tuple:
         # As described in https://tools.ietf.org/html/rfc6749#section-4.3.3
         token, expires_in = request_new_grant_with_post(
             self.token_url, self.data, self.token_field_name, self.client
@@ -404,7 +404,7 @@ class OAuth2AuthorizationCode(httpx.Auth, SupportMultiAuth, BrowserAuth):
         request.headers[self.header_name] = self.header_value.format(token=token)
         yield request
 
-    def request_new_token(self):
+    def request_new_token(self) -> tuple:
         # Request code
         state, code = oauth2_authentication_responses_server.request_new_grant(
             self.code_grant_details
@@ -1119,12 +1119,12 @@ class _MultiAuth(httpx.Auth):
             next(authentication_mode.auth_flow(request))
         yield request
 
-    def __add__(self, other):
+    def __add__(self, other) -> "_MultiAuth":
         if isinstance(other, _MultiAuth):
             return _MultiAuth(*self.authentication_modes, *other.authentication_modes)
         return _MultiAuth(*self.authentication_modes, other)
 
-    def __and__(self, other):
+    def __and__(self, other) -> "_MultiAuth":
         if isinstance(other, _MultiAuth):
             return _MultiAuth(*self.authentication_modes, *other.authentication_modes)
         return _MultiAuth(*self.authentication_modes, other)

--- a/httpx_auth/authentication.py
+++ b/httpx_auth/authentication.py
@@ -149,6 +149,9 @@ class OAuth2ResourceOwnerPasswordCredentials(httpx.Auth, SupportMultiAuth):
         Token will be sent as "Bearer {token}" by default.
         :param scope: Scope parameter sent to token URL as body. Can also be a list of scopes. Not sent by default.
         :param token_field_name: Field name containing the token. access_token by default.
+        :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
+        Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
+        reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
         :param client: httpx.Client instance that will be used to request the token.
         Use it to provide a custom proxying rule for instance.
         :param kwargs: all additional authorization parameters that should be put as body parameters in the token URL.
@@ -169,7 +172,7 @@ class OAuth2ResourceOwnerPasswordCredentials(httpx.Auth, SupportMultiAuth):
             raise Exception("header_value parameter must contains {token}.")
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
-        self.early_expiry = 30.0
+        self.early_expiry = float(kwargs.pop("early_expiry", None) or 30.0)
 
         # Time is expressed in seconds
         self.timeout = int(kwargs.pop("timeout", None) or 60)

--- a/httpx_auth/authentication.py
+++ b/httpx_auth/authentication.py
@@ -193,7 +193,9 @@ class OAuth2ResourceOwnerPasswordCredentials(httpx.Auth, SupportMultiAuth):
     def auth_flow(
         self, request: httpx.Request
     ) -> Generator[httpx.Request, httpx.Response, None]:
-        token = OAuth2.token_cache.get_token(self.state, self.request_new_token)
+        token = OAuth2.token_cache.get_token(
+            self.state, on_missing_token=self.request_new_token
+        )
         request.headers[self.header_name] = self.header_value.format(token=token)
         yield request
 
@@ -269,7 +271,9 @@ class OAuth2ClientCredentials(httpx.Auth, SupportMultiAuth):
     def auth_flow(
         self, request: httpx.Request
     ) -> Generator[httpx.Request, httpx.Response, None]:
-        token = OAuth2.token_cache.get_token(self.state, self.request_new_token)
+        token = OAuth2.token_cache.get_token(
+            self.state, on_missing_token=self.request_new_token
+        )
         request.headers[self.header_name] = self.header_value.format(token=token)
         yield request
 
@@ -400,7 +404,9 @@ class OAuth2AuthorizationCode(httpx.Auth, SupportMultiAuth, BrowserAuth):
     def auth_flow(
         self, request: httpx.Request
     ) -> Generator[httpx.Request, httpx.Response, None]:
-        token = OAuth2.token_cache.get_token(self.state, self.request_new_token)
+        token = OAuth2.token_cache.get_token(
+            self.state, on_missing_token=self.request_new_token
+        )
         request.headers[self.header_name] = self.header_value.format(token=token)
         yield request
 
@@ -546,7 +552,9 @@ class OAuth2AuthorizationCodePKCE(httpx.Auth, SupportMultiAuth, BrowserAuth):
     def auth_flow(
         self, request: httpx.Request
     ) -> Generator[httpx.Request, httpx.Response, None]:
-        token = OAuth2.token_cache.get_token(self.state, self.request_new_token)
+        token = OAuth2.token_cache.get_token(
+            self.state, on_missing_token=self.request_new_token
+        )
         request.headers[self.header_name] = self.header_value.format(token=token)
         yield request
 
@@ -694,8 +702,8 @@ class OAuth2Implicit(httpx.Auth, SupportMultiAuth, BrowserAuth):
     ) -> Generator[httpx.Request, httpx.Response, None]:
         token = OAuth2.token_cache.get_token(
             self.state,
-            oauth2_authentication_responses_server.request_new_grant,
-            self.grant_details,
+            on_missing_token=oauth2_authentication_responses_server.request_new_grant,
+            grant_details=self.grant_details,
         )
         request.headers[self.header_name] = self.header_value.format(token=token)
         yield request

--- a/httpx_auth/authentication.py
+++ b/httpx_auth/authentication.py
@@ -169,6 +169,7 @@ class OAuth2ResourceOwnerPasswordCredentials(httpx.Auth, SupportMultiAuth):
             raise Exception("header_value parameter must contains {token}.")
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
+        self.early_expiry = 30.0
 
         # Time is expressed in seconds
         self.timeout = int(kwargs.pop("timeout", None) or 60)
@@ -194,7 +195,9 @@ class OAuth2ResourceOwnerPasswordCredentials(httpx.Auth, SupportMultiAuth):
         self, request: httpx.Request
     ) -> Generator[httpx.Request, httpx.Response, None]:
         token = OAuth2.token_cache.get_token(
-            self.state, on_missing_token=self.request_new_token
+            self.state,
+            early_expiry=self.early_expiry,
+            on_missing_token=self.request_new_token,
         )
         request.headers[self.header_name] = self.header_value.format(token=token)
         yield request
@@ -250,6 +253,7 @@ class OAuth2ClientCredentials(httpx.Auth, SupportMultiAuth):
             raise Exception("header_value parameter must contains {token}.")
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
+        self.early_expiry = 30.0
 
         # Time is expressed in seconds
         self.timeout = int(kwargs.pop("timeout", None) or 60)
@@ -272,7 +276,9 @@ class OAuth2ClientCredentials(httpx.Auth, SupportMultiAuth):
         self, request: httpx.Request
     ) -> Generator[httpx.Request, httpx.Response, None]:
         token = OAuth2.token_cache.get_token(
-            self.state, on_missing_token=self.request_new_token
+            self.state,
+            early_expiry=self.early_expiry,
+            on_missing_token=self.request_new_token,
         )
         request.headers[self.header_name] = self.header_value.format(token=token)
         yield request
@@ -350,6 +356,7 @@ class OAuth2AuthorizationCode(httpx.Auth, SupportMultiAuth, BrowserAuth):
             raise Exception("header_value parameter must contains {token}.")
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
+        self.early_expiry = 30.0
 
         username = kwargs.pop("username", None)
         password = kwargs.pop("password", None)
@@ -405,7 +412,9 @@ class OAuth2AuthorizationCode(httpx.Auth, SupportMultiAuth, BrowserAuth):
         self, request: httpx.Request
     ) -> Generator[httpx.Request, httpx.Response, None]:
         token = OAuth2.token_cache.get_token(
-            self.state, on_missing_token=self.request_new_token
+            self.state,
+            early_expiry=self.early_expiry,
+            on_missing_token=self.request_new_token,
         )
         request.headers[self.header_name] = self.header_value.format(token=token)
         yield request
@@ -491,6 +500,7 @@ class OAuth2AuthorizationCodePKCE(httpx.Auth, SupportMultiAuth, BrowserAuth):
             raise Exception("header_value parameter must contains {token}.")
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
+        self.early_expiry = 30.0
 
         # As described in https://tools.ietf.org/html/rfc6749#section-4.1.2
         code_field_name = kwargs.pop("code_field_name", "code")
@@ -553,7 +563,9 @@ class OAuth2AuthorizationCodePKCE(httpx.Auth, SupportMultiAuth, BrowserAuth):
         self, request: httpx.Request
     ) -> Generator[httpx.Request, httpx.Response, None]:
         token = OAuth2.token_cache.get_token(
-            self.state, on_missing_token=self.request_new_token
+            self.state,
+            early_expiry=self.early_expiry,
+            on_missing_token=self.request_new_token,
         )
         request.headers[self.header_name] = self.header_value.format(token=token)
         yield request
@@ -675,6 +687,8 @@ class OAuth2Implicit(httpx.Auth, SupportMultiAuth, BrowserAuth):
                 "id_token" if "id_token" == response_type else "access_token"
             )
 
+        self.early_expiry = 30.0
+
         authorization_url_without_nonce = _add_parameters(
             self.authorization_url, kwargs
         )
@@ -702,6 +716,7 @@ class OAuth2Implicit(httpx.Auth, SupportMultiAuth, BrowserAuth):
     ) -> Generator[httpx.Request, httpx.Response, None]:
         token = OAuth2.token_cache.get_token(
             self.state,
+            early_expiry=self.early_expiry,
             on_missing_token=oauth2_authentication_responses_server.request_new_grant,
             grant_details=self.grant_details,
         )

--- a/httpx_auth/aws.py
+++ b/httpx_auth/aws.py
@@ -186,7 +186,7 @@ class AWS4Auth(httpx.Auth):
         sig_string = "\n".join(sig_items)
         return sig_string
 
-    def _amz_cano_path(self, path):
+    def _amz_cano_path(self, path) -> str:
         """
         Generate the canonical path as per AWS4 auth requirements.
         Not documented anywhere, determined from aws4_testsuite examples,
@@ -208,7 +208,7 @@ class AWS4Auth(httpx.Auth):
         return quote(full_path, safe=safe_chars)
 
     @staticmethod
-    def _amz_cano_querystring(qs):
+    def _amz_cano_querystring(qs: str) -> str:
         """
         Parse and format querystring as per AWS4 auth requirements.
         Perform percent quoting as needed.
@@ -233,7 +233,7 @@ class AWS4Auth(httpx.Auth):
         return qs
 
     @staticmethod
-    def _amz_norm_whitespace(text):
+    def _amz_norm_whitespace(text: str) -> str:
         """
         Replace runs of whitespace with a single space.
         Ignore text enclosed in quotes.

--- a/httpx_auth/oauth2_authentication_responses_server.py
+++ b/httpx_auth/oauth2_authentication_responses_server.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class OAuth2ResponseHandler(BaseHTTPRequestHandler):
-    def do_GET(self):
+    def do_GET(self) -> None:
         # Do not consider a favicon request as an error
         if self.path == "/favicon.ico":
             logger.debug(
@@ -42,7 +42,7 @@ class OAuth2ResponseHandler(BaseHTTPRequestHandler):
                 self.error_page(f"Unable to properly perform authentication: {e}")
             )
 
-    def do_POST(self):
+    def do_POST(self) -> None:
         logger.debug(f"POST received on {self.path}")
         try:
             form_dict = self._get_form()
@@ -54,7 +54,7 @@ class OAuth2ResponseHandler(BaseHTTPRequestHandler):
                 self.error_page(f"Unable to properly perform authentication: {e}")
             )
 
-    def _parse_grant(self, arguments: dict):
+    def _parse_grant(self, arguments: dict) -> None:
         grants = arguments.get(self.server.grant_details.name)
         if not grants or len(grants) > 1:
             if "error" in arguments:
@@ -75,22 +75,22 @@ class OAuth2ResponseHandler(BaseHTTPRequestHandler):
             )
         )
 
-    def _get_form(self):
+    def _get_form(self) -> dict:
         content_length = int(self.headers.get("Content-Length", 0))
         body_str = self.rfile.read(content_length).decode("utf-8")
         return parse_qs(body_str, keep_blank_values=1)
 
-    def _get_params(self):
+    def _get_params(self) -> dict:
         return parse_qs(urlparse(self.path).query)
 
-    def send_html(self, html_content: str):
+    def send_html(self, html_content: str) -> None:
         self.send_response(200)
         self.send_header("Content-type", "text/html")
         self.end_headers()
         self.wfile.write(str.encode(html_content))
         logger.debug("HTML content sent to client.")
 
-    def success_page(self, text: str):
+    def success_page(self, text: str) -> str:
         return f"""<body onload="window.open('', '_self', ''); window.setTimeout(close, {self.server.grant_details.reception_success_display_time})" style="
         color: #4F8A10;
         background-color: #DFF2BF;
@@ -101,7 +101,7 @@ class OAuth2ResponseHandler(BaseHTTPRequestHandler):
             <div style="border: 1px solid;">{text}</div>
         </body>"""
 
-    def error_page(self, text: str):
+    def error_page(self, text: str) -> str:
         return f"""<body onload="window.open('', '_self', ''); window.setTimeout(close, {self.server.grant_details.reception_failure_display_time})" style="
         color: #D8000C;
         background-color: #FFBABA;
@@ -112,7 +112,7 @@ class OAuth2ResponseHandler(BaseHTTPRequestHandler):
             <div style="border: 1px solid;">{text}</div>
         </body>"""
 
-    def fragment_redirect_page(self):
+    def fragment_redirect_page(self) -> str:
         """Return a page with JS that calls back the server on the url
         original url: scheme://FQDN/path#fragment
         call back url: scheme://FQDN/path?fragment
@@ -131,7 +131,7 @@ class OAuth2ResponseHandler(BaseHTTPRequestHandler):
         window.location.replace(new_url)
         </script></body></html>"""
 
-    def log_message(self, format: str, *args):
+    def log_message(self, format: str, *args) -> None:
         """Make sure that messages are logged even with pythonw (seems like a bug in BaseHTTPRequestHandler)."""
         logger.debug(format, *args)
 
@@ -165,18 +165,18 @@ class FixedHttpServer(HTTPServer):
         self.request_error = None
         self.grant = False
 
-    def finish_request(self, request: socket, client_address):
+    def finish_request(self, request: socket, client_address) -> None:
         """Make sure that timeout is used by the request (seems like a bug in HTTPServer)."""
         request.settimeout(self.timeout)
         HTTPServer.finish_request(self, request, client_address)
 
-    def ensure_no_error_occurred(self):
+    def ensure_no_error_occurred(self) -> bool:
         if self.request_error:
             # Raise error encountered while processing a request if any
             raise self.request_error
         return not self.grant
 
-    def handle_timeout(self):
+    def handle_timeout(self) -> None:
         raise TimeoutOccurred(self.timeout)
 
 
@@ -196,7 +196,7 @@ def request_new_grant(grant_details: GrantDetails) -> (str, str):
         return _wait_for_grant(server)
 
 
-def _open_url(url: str):
+def _open_url(url: str) -> None:
     # Default to Microsoft Internet Explorer to be able to open a new window
     # otherwise this parameter is not taken into account by most browsers
     # Opening a new window allows to focus back once authenticated (JavaScript is closing the only tab)

--- a/httpx_auth/oauth2_tokens.py
+++ b/httpx_auth/oauth2_tokens.py
@@ -83,12 +83,14 @@ class TokenMemoryCache:
                 f'Inserting token expiring on {datetime.datetime.utcfromtimestamp(expiry)} (UTC) with "{key}" key: {token}'
             )
 
-    def get_token(self, key: str, on_missing_token=None, *on_missing_token_args) -> str:
+    def get_token(
+        self, key: str, *, on_missing_token=None, **on_missing_token_kwargs
+    ) -> str:
         """
         Return the bearer token.
         :param key: key identifier of the token
         :param on_missing_token: function to call when token is expired or missing (returning token and expiry tuple)
-        :param on_missing_token_args: arguments of the function
+        :param on_missing_token_kwargs: arguments of the function (key-value arguments)
         :return: the token
         :raise AuthenticationFailed: in case token cannot be retrieved.
         """
@@ -109,7 +111,7 @@ class TokenMemoryCache:
         logger.debug("Token cannot be found in cache.")
         if on_missing_token is not None:
             with self.forbid_concurrent_missing_token_function_call:
-                new_token = on_missing_token(*on_missing_token_args)
+                new_token = on_missing_token(**on_missing_token_kwargs)
                 if len(new_token) == 2:  # Bearer token
                     state, token = new_token
                     self._add_bearer_token(state, token)

--- a/httpx_auth/testing.py
+++ b/httpx_auth/testing.py
@@ -81,7 +81,7 @@ class BrowserMock:
     def __init__(self):
         self.tabs: Dict[str, Tab] = {}
 
-    def open(self, url: str, new: int):
+    def open(self, url: str, new: int) -> bool:
         assert new == 1
         assert url in self.tabs, f"Browser call on {url} was not mocked."
         # Simulate a browser by sending the response in another thread

--- a/httpx_auth/testing.py
+++ b/httpx_auth/testing.py
@@ -19,7 +19,7 @@ def create_token(expiry: Optional[datetime.datetime]) -> str:
 
 
 @pytest.fixture
-def token_cache():
+def token_cache() -> httpx_auth.oauth2_tokens.TokenMemoryCache:
     yield httpx_auth.OAuth2.token_cache
     httpx_auth.OAuth2.token_cache.clear()
 

--- a/httpx_auth/version.py
+++ b/httpx_auth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/httpx_auth/version.py
+++ b/httpx_auth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Build Tools",
     ],
-    keywords=["authentication"],
+    keywords=["authentication", "oauth2", "aws", "okta", "aad"],
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         # Used for Base Authentication and to communicate with OAuth2 servers

--- a/tests/test_json_token_file_cache.py
+++ b/tests/test_json_token_file_cache.py
@@ -17,11 +17,11 @@ def token_cache(request):
 def test_add_bearer_tokens(token_cache):
     expiry_in_1_hour = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
     token1 = jwt.encode({"exp": expiry_in_1_hour}, "secret").decode("unicode_escape")
-    token_cache.add_bearer_token("key1", token1)
+    token_cache._add_bearer_token("key1", token1)
 
     expiry_in_2_hour = datetime.datetime.utcnow() + datetime.timedelta(hours=2)
     token2 = jwt.encode({"exp": expiry_in_2_hour}, "secret").decode("unicode_escape")
-    token_cache.add_bearer_token("key2", token2)
+    token_cache._add_bearer_token("key2", token2)
 
     # Assert that tokens can be retrieved properly even after other token were inserted
     assert token_cache.get_token("key1") == token1
@@ -35,11 +35,11 @@ def test_add_bearer_tokens(token_cache):
 def test_save_bearer_tokens(token_cache, request):
     expiry_in_1_hour = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
     token1 = jwt.encode({"exp": expiry_in_1_hour}, "secret").decode("unicode_escape")
-    token_cache.add_bearer_token("key1", token1)
+    token_cache._add_bearer_token("key1", token1)
 
     expiry_in_2_hour = datetime.datetime.utcnow() + datetime.timedelta(hours=2)
     token2 = jwt.encode({"exp": expiry_in_2_hour}, "secret").decode("unicode_escape")
-    token_cache.add_bearer_token("key2", token2)
+    token_cache._add_bearer_token("key2", token2)
 
     same_cache = httpx_auth.JsonTokenFileCache(request.node.name + ".cache")
     assert same_cache.get_token("key1") == token1
@@ -56,7 +56,7 @@ def test_save_bearer_token_exception_handling(token_cache, request, monkeypatch)
     token1 = jwt.encode({"exp": expiry_in_1_hour}, "secret").decode("unicode_escape")
 
     # Assert that the exception is not thrown
-    token_cache.add_bearer_token("key1", token1)
+    token_cache._add_bearer_token("key1", token1)
 
     same_cache = httpx_auth.JsonTokenFileCache(request.node.name + ".cache")
     with pytest.raises(httpx_auth.AuthenticationFailed) as exception_info:

--- a/tests/test_json_token_file_cache.py
+++ b/tests/test_json_token_file_cache.py
@@ -72,5 +72,7 @@ def test_missing_token(token_cache):
 def test_missing_token_function(token_cache):
     expiry_in_1_hour = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
     token = jwt.encode({"exp": expiry_in_1_hour}, "secret").decode("unicode_escape")
-    retrieved_token = token_cache.get_token("key1", lambda: ("key1", token))
+    retrieved_token = token_cache.get_token(
+        "key1", on_missing_token=lambda: ("key1", token)
+    )
     assert retrieved_token == token

--- a/tests/test_oauth2_authorization_code.py
+++ b/tests/test_oauth2_authorization_code.py
@@ -72,6 +72,64 @@ def test_oauth2_authorization_code_flow_get_code_is_sent_in_authorization_header
     )
 
 
+def test_oauth2_authorization_code_flow_get_code_is_expired_after_30_seconds_by_default(
+    token_cache, httpx_mock: HTTPXMock, browser_mock: BrowserMock
+):
+    auth = httpx_auth.OAuth2AuthorizationCode(
+        "http://provide_code", "http://provide_access_token"
+    )
+    # Add a token that expires in 29 seconds, so should be considered as expired when issuing the request
+    token_cache._add_token(
+        key="163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    # Meaning a new one will be requested
+    tab = browser_mock.add_response(
+        opened_url="http://provide_code?response_type=code&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA",
+    )
+    httpx_mock.add_response(
+        match_headers={"Authorization": "Bearer 2YotnFZFEjr1zCsicMWpAA"}
+    )
+    # Send a request to this dummy URL with authentication
+    httpx.get("http://authorized_only", auth=auth)
+    tab.assert_success(
+        "You are now authenticated on 163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de. You may close this tab."
+    )
+
+
+def test_oauth2_authorization_code_flow_get_code_custom_expiry(
+    token_cache, httpx_mock: HTTPXMock, browser_mock: BrowserMock
+):
+    auth = httpx_auth.OAuth2AuthorizationCode(
+        "http://provide_code", "http://provide_access_token", early_expiry=28
+    )
+    # Add a token that expires in 29 seconds, so should be considered as not expired when issuing the request
+    token_cache._add_token(
+        key="163f0455b3e9cad3ca04254e5a0169553100d3aa0756c7964d897da316a695ffed5b4f46ef305094fd0a88cfe4b55ff257652015e4aa8f87b97513dba440f8de",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    httpx_mock.add_response(
+        match_headers={"Authorization": "Bearer 2YotnFZFEjr1zCsicMWpAA"}
+    )
+    # Send a request to this dummy URL with authentication
+    httpx.get("http://authorized_only", auth=auth)
+
+
 def test_empty_token_is_invalid(
     token_cache, httpx_mock: HTTPXMock, browser_mock: BrowserMock
 ):

--- a/tests/test_oauth2_authorization_code_okta.py
+++ b/tests/test_oauth2_authorization_code_okta.py
@@ -73,6 +73,64 @@ def test_oauth2_authorization_code_flow_get_code_is_sent_in_authorization_header
     )
 
 
+def test_oauth2_authorization_code_flow_get_code_is_expired_after_30_seconds_by_default(
+    token_cache, httpx_mock: HTTPXMock, browser_mock: BrowserMock
+):
+    auth = httpx_auth.OktaAuthorizationCode(
+        "testserver.okta-emea.com", "54239d18-c68c-4c47-8bdd-ce71ea1d50cd"
+    )
+    # Add a token that expires in 29 seconds, so should be considered as expired when issuing the request
+    token_cache._add_token(
+        key="5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    # Meaning a new one will be requested
+    tab = browser_mock.add_response(
+        opened_url="https://testserver.okta-emea.com/oauth2/default/v1/authorize?client_id=54239d18-c68c-4c47-8bdd-ce71ea1d50cd&scope=openid&response_type=code&state=5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&client_id=54239d18-c68c-4c47-8bdd-ce71ea1d50cd&scope=openid&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA",
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    tab.assert_success(
+        "You are now authenticated on 5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b. You may close this tab."
+    )
+
+
+def test_oauth2_authorization_code_flow_get_code_custom_expiry(
+    token_cache, httpx_mock: HTTPXMock, browser_mock: BrowserMock
+):
+    auth = httpx_auth.OktaAuthorizationCode(
+        "testserver.okta-emea.com",
+        "54239d18-c68c-4c47-8bdd-ce71ea1d50cd",
+        early_expiry=28,
+    )
+    # Add a token that expires in 29 seconds, so should be considered as not expired when issuing the request
+    token_cache._add_token(
+        key="5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
 def test_empty_token_is_invalid(
     token_cache, httpx_mock: HTTPXMock, browser_mock: BrowserMock
 ):

--- a/tests/test_oauth2_authorization_code_pkce_okta.py
+++ b/tests/test_oauth2_authorization_code_pkce_okta.py
@@ -75,6 +75,66 @@ def test_oauth2_pkce_flow_get_code_is_sent_in_authorization_header_by_default(
     )
 
 
+def test_oauth2_pkce_flow_get_code_is_expired_after_30_seconds_by_default(
+    token_cache, httpx_mock: HTTPXMock, monkeypatch, browser_mock: BrowserMock
+):
+    monkeypatch.setattr(httpx_auth.authentication.os, "urandom", lambda x: b"1" * 63)
+    auth = httpx_auth.OktaAuthorizationCodePKCE(
+        "testserver.okta-emea.com", "54239d18-c68c-4c47-8bdd-ce71ea1d50cd"
+    )
+    # Add a token that expires in 29 seconds, so should be considered as expired when issuing the request
+    token_cache._add_token(
+        key="5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    # Meaning a new one will be requested
+    tab = browser_mock.add_response(
+        opened_url="https://testserver.okta-emea.com/oauth2/default/v1/authorize?client_id=54239d18-c68c-4c47-8bdd-ce71ea1d50cd&scope=openid&response_type=code&state=5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&code_challenge=5C_ph_KZ3DstYUc965SiqmKAA-ShvKF4Ut7daKd3fjc&code_challenge_method=S256",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"code_verifier=MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEx&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&client_id=54239d18-c68c-4c47-8bdd-ce71ea1d50cd&scope=openid&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA",
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    tab.assert_success(
+        "You are now authenticated on 5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b. You may close this tab."
+    )
+
+
+def test_oauth2_pkce_flow_get_code_custom_expiry(
+    token_cache, httpx_mock: HTTPXMock, monkeypatch, browser_mock: BrowserMock
+):
+    monkeypatch.setattr(httpx_auth.authentication.os, "urandom", lambda x: b"1" * 63)
+    auth = httpx_auth.OktaAuthorizationCodePKCE(
+        "testserver.okta-emea.com",
+        "54239d18-c68c-4c47-8bdd-ce71ea1d50cd",
+        early_expiry=28,
+    )
+    # Add a token that expires in 29 seconds, so should be considered as not expired when issuing the request
+    token_cache._add_token(
+        key="5264d11c8b268ccf911ce564ca42fd75cea68c4a3c1ec3ac1ab20243891ab7cd5250ad4c2d002017c6e8ac2ba34954293baa5e0e4fd00bb9ffd4a39c45f1960b",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
 def test_expires_in_sent_as_str(
     token_cache, httpx_mock: HTTPXMock, monkeypatch, browser_mock: BrowserMock
 ):

--- a/tests/test_oauth2_client_credential.py
+++ b/tests/test_oauth2_client_credential.py
@@ -95,7 +95,7 @@ def test_oauth2_client_credentials_flow_token_custom_expiry(
         "http://provide_access_token",
         client_id="test_user",
         client_secret="test_pwd",
-        early_expiry=29,
+        early_expiry=28,
     )
     # Add a token that expires in 29 seconds, so should be considered as not expired when issuing the request
     token_cache._add_token(

--- a/tests/test_oauth2_client_credential.py
+++ b/tests/test_oauth2_client_credential.py
@@ -58,6 +58,57 @@ def test_oauth2_client_credentials_flow_token_is_sent_in_authorization_header_by
     )
 
 
+def test_oauth2_client_credentials_flow_token_is_expired_after_30_seconds_by_default(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OAuth2ClientCredentials(
+        "http://provide_access_token", client_id="test_user", client_secret="test_pwd"
+    )
+    # Add a token that expires in 29 seconds, so should be considered as expired when issuing the request
+    token_cache._add_token(
+        key="a8a1c17ded24b3710524306819084310b08f97e151c79f4f1979202c541f3e8506c93176f7ee816bfcd2b2f6de9c5c3e16aaff220f1ad8f08d31ee086e8618da",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    # Meaning a new one will be requested
+    httpx_mock.add_response(
+        method="POST",
+        url="http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
+def test_oauth2_client_credentials_flow_token_custom_expiry(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OAuth2ClientCredentials(
+        "http://provide_access_token",
+        client_id="test_user",
+        client_secret="test_pwd",
+        early_expiry=29,
+    )
+    # Add a token that expires in 29 seconds, so should be considered as not expired when issuing the request
+    token_cache._add_token(
+        key="a8a1c17ded24b3710524306819084310b08f97e151c79f4f1979202c541f3e8506c93176f7ee816bfcd2b2f6de9c5c3e16aaff220f1ad8f08d31ee086e8618da",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
 def test_expires_in_sent_as_str(token_cache, httpx_mock: HTTPXMock):
     auth = httpx_auth.OAuth2ClientCredentials(
         "http://provide_access_token", client_id="test_user", client_secret="test_pwd"

--- a/tests/test_oauth2_client_credential_okta.py
+++ b/tests/test_oauth2_client_credential_okta.py
@@ -88,7 +88,7 @@ def test_okta_client_credentials_flow_token_custom_expiry(
     token_cache, httpx_mock: HTTPXMock
 ):
     auth = httpx_auth.OktaClientCredentials(
-        "test_okta", client_id="test_user", client_secret="test_pwd", early_expiry=29
+        "test_okta", client_id="test_user", client_secret="test_pwd", early_expiry=28
     )
     # Add a token that expires in 29 seconds, so should be considered as not expired when issuing the request
     token_cache._add_token(

--- a/tests/test_oauth2_client_credential_okta.py
+++ b/tests/test_oauth2_client_credential_okta.py
@@ -54,6 +54,54 @@ def test_okta_client_credentials_flow_token_is_sent_in_authorization_header_by_d
     )
 
 
+def test_okta_client_credentials_flow_token_is_expired_after_30_seconds_by_default(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaClientCredentials(
+        "test_okta", client_id="test_user", client_secret="test_pwd"
+    )
+    # Add a token that expires in 29 seconds, so should be considered as expired when issuing the request
+    token_cache._add_token(
+        key="f0d25aa4e496c6615328e776bb981dabe53fa77768a0a58eaf6d54215c598d80e57ffc7926fd96ec6a6a872942cb684a473e36233b593fb760d3eb6dc22ae550",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    # Meaning a new one will be requested
+    httpx_mock.add_response(
+        method="POST",
+        url="https://test_okta/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
+def test_okta_client_credentials_flow_token_custom_expiry(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaClientCredentials(
+        "test_okta", client_id="test_user", client_secret="test_pwd", early_expiry=29
+    )
+    # Add a token that expires in 29 seconds, so should be considered as not expired when issuing the request
+    token_cache._add_token(
+        key="f0d25aa4e496c6615328e776bb981dabe53fa77768a0a58eaf6d54215c598d80e57ffc7926fd96ec6a6a872942cb684a473e36233b593fb760d3eb6dc22ae550",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
 def test_expires_in_sent_as_str(token_cache, httpx_mock: HTTPXMock):
     auth = httpx_auth.OktaClientCredentials(
         "test_okta", client_id="test_user", client_secret="test_pwd"

--- a/tests/test_oauth2_resource_owner_password.py
+++ b/tests/test_oauth2_resource_owner_password.py
@@ -79,7 +79,7 @@ def test_oauth2_password_credentials_flow_token_is_expired_after_30_seconds_by_d
         json={
             "access_token": "2YotnFZFEjr1zCsicMWpAA",
             "token_type": "example",
-            "expires_in": 29,
+            "expires_in": 3600,
             "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
             "example_parameter": "example_value",
         },

--- a/tests/test_oauth2_resource_owner_password.py
+++ b/tests/test_oauth2_resource_owner_password.py
@@ -60,6 +60,58 @@ def test_oauth2_password_credentials_flow_token_is_sent_in_authorization_header_
     )
 
 
+def test_oauth2_password_credentials_flow_token_is_expired_after_30_seconds_by_default(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OAuth2ResourceOwnerPasswordCredentials(
+        "http://provide_access_token", username="test_user", password="test_pwd"
+    )
+    # Add a token that expires in 29 seconds, so should be considered as expired when issuing the request
+    token_cache._add_token(
+        key="db2be9203dd2718c7285319dde1270056808482fbf7fffa6a9362d092d1cf799b393dd15140ea13e4d76d1603e56390a6222ff7063736a1b686d317706b2c001",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    # Meaning a new one will be requested
+    httpx_mock.add_response(
+        method="POST",
+        url="http://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 29,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"grant_type=password&username=test_user&password=test_pwd",
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
+def test_oauth2_password_credentials_flow_token_custom_expiry(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OAuth2ResourceOwnerPasswordCredentials(
+        "http://provide_access_token",
+        username="test_user",
+        password="test_pwd",
+        early_expiry=29,
+    )
+    # Add a token that expires in 29 seconds, so should be considered as not expired when issuing the request
+    token_cache._add_token(
+        key="db2be9203dd2718c7285319dde1270056808482fbf7fffa6a9362d092d1cf799b393dd15140ea13e4d76d1603e56390a6222ff7063736a1b686d317706b2c001",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
 def test_expires_in_sent_as_str(token_cache, httpx_mock: HTTPXMock):
     auth = httpx_auth.OAuth2ResourceOwnerPasswordCredentials(
         "http://provide_access_token", username="test_user", password="test_pwd"

--- a/tests/test_oauth2_resource_owner_password.py
+++ b/tests/test_oauth2_resource_owner_password.py
@@ -98,7 +98,7 @@ def test_oauth2_password_credentials_flow_token_custom_expiry(
         "http://provide_access_token",
         username="test_user",
         password="test_pwd",
-        early_expiry=29,
+        early_expiry=28,
     )
     # Add a token that expires in 29 seconds, so should be considered as not expired when issuing the request
     token_cache._add_token(


### PR DESCRIPTION
### Removed
- Do not expose `httpx_auth.oauth2_tokens.decode_base64` function anymore as it supposed to be used internally only.
- Do not expose `add_bearer_token` token cache method anymore as it supposed to be used internally only.
- Do not expose `add_access_token` token cache method anymore as it supposed to be used internally only.

### Changed
- `get_token` cache method now requires `on_missing_token` function args to be provided as kwargs instead of args.
- `get_token` cache method now requires `on_missing_token` parameter to be provided as a non positional argument.
- `get_token` cache method now expose `early_expiry` parameter, defaulting to 30 seconds.

### Fixed
- OAuth2 token will now be considered as expired 30 seconds before actual expiry. To ensure it is still valid when received by the actual server.

### Added
- `httpx_auth.OAuth2ResourceOwnerPasswordCredentials` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
- `httpx_auth.OAuth2ClientCredentials` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
- `httpx_auth.OktaClientCredentials` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
- `httpx_auth.OAuth2AuthorizationCode` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
- `httpx_auth.OktaAuthorizationCode` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
- `httpx_auth.OAuth2AuthorizationCodePKCE` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
- `httpx_auth.OktaAuthorizationCodePKCE` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
- `httpx_auth.OAuth2Implicit` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
- `httpx_auth.AzureActiveDirectoryImplicit` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
- `httpx_auth.AzureActiveDirectoryImplicitIdToken` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
- `httpx_auth.OktaImplicit` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
- `httpx_auth.OktaImplicitIdToken` contains a new `early_expiry` parameter allowing to tweak the number of seconds before actual token expiry where the token will be considered as already expired. Default to 30s.
