### PR TITLE
Release 0.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - pip install .[testing]
 script:
   - pytest --cov=httpx_auth --cov-fail-under=100 --cov-report=term-missing
+  - pip install idna==2.10
 deploy:
   provider: pypi
   username: __token__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.9.0] - 2021-03-01
 ### Changed
 - Requires [`httpx`](https://www.python-httpx.org)==0.17.\*
 
@@ -97,7 +99,8 @@ Note that a few changes were made:
 ### Added
 - Placeholder for port of requests_auth to httpx
 
-[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/Colin-b/httpx_auth/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Colin-b/httpx_auth/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Colin-b/httpx_auth/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Colin-b/httpx_auth/compare/v0.5.1...v0.6.0

--- a/httpx_auth/version.py
+++ b/httpx_auth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
             # Used to generate test tokens
             "pyjwt==1.*",
             # Used to mock httpx
-            "pytest_httpx==0.10.*",
+            "pytest_httpx==0.11.*",
             # Used to check coverage
             "pytest-cov==2.*",
         ]


### PR DESCRIPTION
### Changed
- Requires [`httpx`](https://www.python-httpx.org)==0.17.\*
