### PR TITLE
Release 0.11.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.7b0
     hooks:
       - id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2021-08-19
+### Changed
+- Requires [`httpx`](https://www.python-httpx.org)==0.19.\*
+
 ## [0.10.0] - 2021-04-27
 ### Changed
 - Requires [`httpx`](https://www.python-httpx.org)==0.18.\*
@@ -103,7 +107,8 @@ Note that a few changes were made:
 ### Added
 - Placeholder for port of requests_auth to httpx
 
-[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/Colin-b/httpx_auth/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/Colin-b/httpx_auth/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Colin-b/httpx_auth/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Colin-b/httpx_auth/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Requires [`httpx`](https://www.python-httpx.org)==0.19.\*
 
+### Fixed
+- Tild character (`~`) is not URL encoded anymore.
+
 ## [0.10.0] - 2021-04-27
 ### Changed
 - Requires [`httpx`](https://www.python-httpx.org)==0.18.\*

--- a/httpx_auth/errors.py
+++ b/httpx_auth/errors.py
@@ -5,14 +5,14 @@ import httpx
 
 
 class AuthenticationFailed(Exception):
-    """ User was not authenticated. """
+    """User was not authenticated."""
 
     def __init__(self):
         Exception.__init__(self, "User was not authenticated.")
 
 
 class TimeoutOccurred(Exception):
-    """ No response within timeout interval. """
+    """No response within timeout interval."""
 
     def __init__(self, timeout: float):
         Exception.__init__(
@@ -21,14 +21,14 @@ class TimeoutOccurred(Exception):
 
 
 class InvalidToken(Exception):
-    """ Token is invalid. """
+    """Token is invalid."""
 
     def __init__(self, token_name: str):
         Exception.__init__(self, f"{token_name} is invalid.")
 
 
 class GrantNotProvided(Exception):
-    """ Grant was not provided. """
+    """Grant was not provided."""
 
     def __init__(self, grant_name: str, dictionary_without_grant: dict):
         Exception.__init__(
@@ -115,7 +115,7 @@ class InvalidGrantRequest(Exception):
 
 
 class StateNotProvided(Exception):
-    """ State was not provided. """
+    """State was not provided."""
 
     def __init__(self, dictionary_without_state: dict):
         Exception.__init__(
@@ -124,7 +124,7 @@ class StateNotProvided(Exception):
 
 
 class TokenExpiryNotProvided(Exception):
-    """ Token expiry was not provided. """
+    """Token expiry was not provided."""
 
     def __init__(self, token_body: dict):
         Exception.__init__(self, f"Expiry (exp) is not provided in {token_body}.")

--- a/httpx_auth/version.py
+++ b/httpx_auth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/setup.py
+++ b/setup.py
@@ -36,14 +36,14 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         # Used for Base Authentication and to communicate with OAuth2 servers
-        "httpx==0.18.*"
+        "httpx==0.19.*"
     ],
     extras_require={
         "testing": [
             # Used to generate test tokens
             "pyjwt==1.*",
             # Used to mock httpx
-            "pytest_httpx==0.12.*",
+            "pytest_httpx==0.13.*",
             # Used to check coverage
             "pytest-cov==2.*",
         ]

--- a/tests/test_aws4auth.py
+++ b/tests/test_aws4auth.py
@@ -534,7 +534,7 @@ def test_aws_auth_path_quoting(httpx_mock: HTTPXMock, mock_aws_datetime):
         service="iam",
     )
     httpx_mock.add_response(
-        url="http://authorized_only/test/hello-*.&%5E%7E+%7B%7D!$%C2%A3_%20"
+        url="http://authorized_only/test/hello-*.&%5E~+%7B%7D!$%C2%A3_%20"
     )
 
     httpx.post("http://authorized_only/test/hello-*.&^~+{}!$£_ ", auth=auth)
@@ -558,7 +558,7 @@ def test_aws_auth_path_percent_encode_non_s3(httpx_mock: HTTPXMock, mock_aws_dat
         service="iam",
     )
     httpx_mock.add_response(
-        url="http://authorized_only/test/%252a%252b%2525/%7E-_%5E&%20%25%25"
+        url="http://authorized_only/test/%252a%252b%2525/~-_%5E&%20%25%25"
     )
 
     httpx.post("http://authorized_only/test/%2a%2b%25/~-_^& %%", auth=auth)
@@ -582,7 +582,7 @@ def test_aws_auth_path_percent_encode_s3(httpx_mock: HTTPXMock, mock_aws_datetim
         service="s3",
     )
     httpx_mock.add_response(
-        url="http://authorized_only/test/%252a%252b%2525/%7E-_%5E&%20%25%25"
+        url="http://authorized_only/test/%252a%252b%2525/~-_%5E&%20%25%25"
     )
 
     httpx.post("http://authorized_only/test/%2a%2b%25/~-_^& %%", auth=auth)

--- a/tests/test_aws4auth.py
+++ b/tests/test_aws4auth.py
@@ -545,7 +545,7 @@ def test_aws_auth_path_quoting(httpx_mock: HTTPXMock, mock_aws_datetime):
     )
     assert (
         headers["Authorization"]
-        == "AWS4-HMAC-SHA256 Credential=access_id/20181011/us-east-1/iam/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=98dd3cdd2a603907495164f08fe7197fb405bf8c556ddf7b88d7e15341a9588a"
+        == "AWS4-HMAC-SHA256 Credential=access_id/20181011/us-east-1/iam/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=f3c8efd9b81b952035a73ea93d3a79380e13370bcaa6089e4275319bde17a400"
     )
     assert headers["x-amz-date"] == "20181011T150505Z"
 
@@ -569,7 +569,7 @@ def test_aws_auth_path_percent_encode_non_s3(httpx_mock: HTTPXMock, mock_aws_dat
     )
     assert (
         headers["Authorization"]
-        == "AWS4-HMAC-SHA256 Credential=access_id/20181011/us-east-1/iam/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=1da6c689b7a20044144a9f265ddecc38b1b884902846fbe4dc8049595f25565f"
+        == "AWS4-HMAC-SHA256 Credential=access_id/20181011/us-east-1/iam/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=289c2090b71ada48944fbf204e99cf305effeb54b87932215dc7b2b6a3203722"
     )
     assert headers["x-amz-date"] == "20181011T150505Z"
 


### PR DESCRIPTION
### Changed
- Requires [`httpx`](https://www.python-httpx.org)==0.19.\*

### Fixed
- Tild character (`~`) is not URL encoded anymore.