### PR TITLE
Release 0.14.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         pytest --cov=httpx_auth --cov-fail-under=100 --cov-report=term-missing
     - name: Create packages
       run: |
+        python -m pip install wheel
         python setup.py sdist bdist_wheel
     - name: Publish packages
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Publish packages
       run: |
         python -m pip install twine
-        python -m twine upload dist\* --skip-existing --username __token__ --password ${{ secrets.pypi_password }}
+        python -m twine upload dist/* --skip-existing --username __token__ --password ${{ secrets.pypi_password }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.12b0
     hooks:
       - id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2022-01-26
+### Changed
+- Requires [`httpx`](https://www.python-httpx.org)==0.22.\*
+
+### Removed
+- Python 3.6 is no longer supported.
+
 ## [0.13.0] - 2021-11-16
 ### Changed
 - Requires [`httpx`](https://www.python-httpx.org)==0.21.\*
@@ -141,7 +148,8 @@ Note that a few changes were made:
 ### Added
 - Placeholder for port of requests_auth to httpx
 
-[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/Colin-b/httpx_auth/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/Colin-b/httpx_auth/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/Colin-b/httpx_auth/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Colin-b/httpx_auth/compare/v0.10.0...v0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2021-11-16
+### Changed
+- Requires [`httpx`](https://www.python-httpx.org)==0.21.\*
+
 ## [0.12.0] - 2021-11-01
 ### Changed
 - Requires [`httpx`](https://www.python-httpx.org)==0.20.\*
@@ -137,7 +141,8 @@ Note that a few changes were made:
 ### Added
 - Placeholder for port of requests_auth to httpx
 
-[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/Colin-b/httpx_auth/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/Colin-b/httpx_auth/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Colin-b/httpx_auth/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/Colin-b/httpx_auth/compare/v0.9.0...v0.10.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Colin Bounouar
+Copyright (c) 2022 Colin Bounouar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/httpx_auth/oauth2_tokens.py
+++ b/httpx_auth/oauth2_tokens.py
@@ -105,7 +105,7 @@ class TokenMemoryCache:
         :param early_expiry: As the time between the token extraction from cache and the token reception on server side
         might not higher than one second, on slow networks, token might be expired when received by the actual server,
         even if still valid when fetched.
-        This is the number of seconds to substract to the actual token expiry. Token will be considered as
+        This is the number of seconds to subtract to the actual token expiry. Token will be considered as
         expired 30 seconds before real expiry by default.
         :param on_missing_token: function to call when token is expired or missing (returning token and expiry tuple)
         :param on_missing_token_kwargs: arguments of the function (key-value arguments)

--- a/httpx_auth/version.py
+++ b/httpx_auth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.13.0"
+__version__ = "0.14.0"

--- a/httpx_auth/version.py
+++ b/httpx_auth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/setup.py
+++ b/setup.py
@@ -36,14 +36,14 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         # Used for Base Authentication and to communicate with OAuth2 servers
-        "httpx==0.20.*"
+        "httpx==0.21.*"
     ],
     extras_require={
         "testing": [
             # Used to generate test tokens
             "pyjwt==2.*",
             # Used to mock httpx
-            "pytest_httpx==0.14.*",
+            "pytest_httpx==0.15.*",
             # Used to check coverage
             "pytest-cov==3.*",
         ]

--- a/setup.py
+++ b/setup.py
@@ -26,29 +26,29 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Build Tools",
     ],
     keywords=["authentication", "oauth2", "aws", "okta", "aad"],
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         # Used for Base Authentication and to communicate with OAuth2 servers
-        "httpx==0.21.*"
+        "httpx==0.22.*"
     ],
     extras_require={
         "testing": [
             # Used to generate test tokens
             "pyjwt==2.*",
             # Used to mock httpx
-            "pytest_httpx==0.15.*",
+            "pytest_httpx==0.19.*",
             # Used to check coverage
             "pytest-cov==3.*",
         ]
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     project_urls={
         "GitHub": "https://github.com/Colin-b/httpx_auth",
         "Changelog": "https://github.com/Colin-b/httpx_auth/blob/master/CHANGELOG.md",


### PR DESCRIPTION
### Changed
- Requires [`httpx`](https://www.python-httpx.org)==0.22.\*

### Removed
- Python 3.6 is no longer supported.
