### PR TITLE
Indicate package is typed per PEP 561

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Type information is now provided following [PEP 561](https://www.python.org/dev/peps/pep-0561/)
 
 ## [0.14.0] - 2022-01-26
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
+        "Typing :: Typed",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
@@ -33,6 +34,7 @@ setup(
         "Topic :: Software Development :: Build Tools",
     ],
     keywords=["authentication", "oauth2", "aws", "okta", "aad"],
+    package_data={"httpx_auth": ["py.typed"]},
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         # Used for Base Authentication and to communicate with OAuth2 servers


### PR DESCRIPTION
Marks the `httpx_auth` package as typed so typecheckers can use the annotations, with the [`Typing :: Typed`](https://pypi.org/search/?c=Typing+%3A%3A+Typed) PyPI classifier as a bonus ^^

**How to test**

In a new virtualenv, run `pip install mypy git+https://github.com/nymous/httpx_auth.git@indicate-typed-package`.
Create the following `main.py`, then run `mypy main.py`
```py
from httpx_auth import OAuth2AuthorizationCode

oauth_class = OAuth2AuthorizationCode('https://www.authorization.url', 'https://www.token.url')

reveal_type(oauth_class)

OAuth2AuthorizationCode(123)  # This will fail mypy
```

*Result before:*
```
main.py:1: error: Skipping analyzing "httpx_auth": module is installed, but missing library stubs or py.typed marker
main.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
main.py:5: note: Revealed type is "Any"
Found 1 error in 1 file (checked 1 source file)
```

*Result after:*
```
main.py:5: note: Revealed type is "httpx_auth.authentication.OAuth2AuthorizationCode"
main.py:7: error: Missing positional argument "token_url" in call to "OAuth2AuthorizationCode"
main.py:7: error: Argument 1 to "OAuth2AuthorizationCode" has incompatible type "int"; expected "str"
Found 2 errors in 1 file (checked 1 source file)
```

**Note:** this will fail if mypy is run with the `--strict` flag (and more precisely `--no-implicit-reexport`), another PR like Colin-b/pytest_httpx#57 will come later.

Fixes #43 (with inspiration from Colin-b/pytest_httpx#44 for the `setup.py` `package_data` and the changelog entry)