### PR TITLE
Explicit reexports to appease `mypy --strict` and pyright

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Type information is now provided following [PEP 561](https://www.python.org/dev/peps/pep-0561/)
+- Allow for users to run `mypy --strict`.
 
 ## [0.14.0] - 2022-01-26
 ### Changed

--- a/httpx_auth/__init__.py
+++ b/httpx_auth/__init__.py
@@ -28,3 +28,32 @@ from httpx_auth.errors import (
     InvalidGrantRequest,
 )
 from httpx_auth.version import __version__
+
+__all__ = [
+    "Basic",
+    "HeaderApiKey",
+    "QueryApiKey",
+    "OAuth2",
+    "OAuth2AuthorizationCodePKCE",
+    "OktaAuthorizationCodePKCE",
+    "OAuth2Implicit",
+    "OktaImplicit",
+    "OktaImplicitIdToken",
+    "AzureActiveDirectoryImplicit",
+    "AzureActiveDirectoryImplicitIdToken",
+    "OAuth2AuthorizationCode",
+    "OktaAuthorizationCode",
+    "OAuth2ClientCredentials",
+    "OktaClientCredentials",
+    "OAuth2ResourceOwnerPasswordCredentials",
+    "JsonTokenFileCache",
+    "AWS4Auth",
+    "GrantNotProvided",
+    "TimeoutOccurred",
+    "AuthenticationFailed",
+    "StateNotProvided",
+    "InvalidToken",
+    "TokenExpiryNotProvided",
+    "InvalidGrantRequest",
+    "__version__",
+]


### PR DESCRIPTION
Explicitly export in `__all__` all imports in `__init__.py`, so that `mypy --strict` and pyright are happy.

**How to test**

In a new virtualenv, run `pip install mypy git+https://github.com/nymous/httpx_auth.git@explicit-reexports`.
Create the following `main.py`, then run `mypy main.py --strict`
```py
from httpx_auth import OAuth2AuthorizationCode

oauth_class = OAuth2AuthorizationCode('https://www.authorization.url', 'https://www.token.url')

reveal_type(oauth_class)

OAuth2AuthorizationCode(123)  # This will fail mypy
```

*Result before:*
```
main.py:1: error: Module "httpx_auth" does not explicitly export attribute "OAuth2AuthorizationCode"; implicit reexport disabled
main.py:5: note: Revealed type is "Any"
Found 1 error in 1 file (checked 1 source file)
```

*Result after:*
```
main.py:5: note: Revealed type is "httpx_auth.authentication.OAuth2AuthorizationCode"
main.py:7: error: Missing positional argument "token_url" in call to "OAuth2AuthorizationCode"
main.py:7: error: Argument 1 to "OAuth2AuthorizationCode" has incompatible type "int"; expected "str"
Found 2 errors in 1 file (checked 1 source file)
```

**Note:** this branch is based on `indicate-typed-package`, because it doesn't affect anything if the package isn't marked as typed. Tell me if I should base it off develop instead.

Fixes #43 (with inspiration from Colin-b/pytest_httpx#57 for the changelog entry)