### PR TITLE
Release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.15.0] - 2022-06-01
+### Changed
 - Requires [`httpx`](https://www.python-httpx.org)==0.23.\*
 
 ## [0.14.1] - 2022-02-05
@@ -154,7 +157,8 @@ Note that a few changes were made:
 ### Added
 - Placeholder for port of requests_auth to httpx
 
-[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.14.1...HEAD
+[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/Colin-b/httpx_auth/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/Colin-b/httpx_auth/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/Colin-b/httpx_auth/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/Colin-b/httpx_auth/compare/v0.12.0...v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Requires [`httpx`](https://www.python-httpx.org)==0.23.\*
 
 ## [0.14.1] - 2022-02-05
 ### Fixed

--- a/httpx_auth/version.py
+++ b/httpx_auth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.14.1"
+__version__ = "0.15.0"

--- a/setup.py
+++ b/setup.py
@@ -38,14 +38,14 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         # Used for Base Authentication and to communicate with OAuth2 servers
-        "httpx==0.22.*"
+        "httpx==0.23.*"
     ],
     extras_require={
         "testing": [
             # Used to generate test tokens
             "pyjwt==2.*",
             # Used to mock httpx
-            "pytest_httpx==0.20.*",
+            "pytest_httpx==0.21.*",
             # Used to check coverage
             "pytest-cov==3.*",
         ]


### PR DESCRIPTION
### Changed
- Requires [`httpx`](https://www.python-httpx.org)==0.23.\*
