### PR TITLE
Release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `httpx_auth.OAuth2ResourceOwnerPasswordCredentials` does not send basic authentication by default.
+
+### Added
+- `client_auth` as a parameter of `httpx_auth.OAuth2ResourceOwnerPasswordCredentials`. Allowing to provide any kind of optional authentication.
 
 ## [0.16.0] - 2023-04-25
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.17.0] - 2023-04-26
 ### Changed
 - `httpx_auth.OAuth2ResourceOwnerPasswordCredentials` does not send basic authentication by default.
 
@@ -176,7 +178,8 @@ Note that a few changes were made:
 ### Added
 - Placeholder for port of requests_auth to httpx
 
-[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/Colin-b/httpx_auth/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Colin-b/httpx_auth/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/Colin-b/httpx_auth/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/Colin-b/httpx_auth/compare/v0.14.0...v0.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `client_auth` as a parameter of `httpx_auth.OAuth2ResourceOwnerPasswordCredentials`. Allowing to provide any kind of optional authentication.
+- `httpx_auth.OktaResourceOwnerPasswordCredentials` providing Okta resource owner password credentials flow easy setup.
 
 ## [0.16.0] - 2023-04-25
 ### Changed

--- a/README.md
+++ b/README.md
@@ -298,18 +298,19 @@ with httpx.Client() as client:
 
 #### Parameters
 
-| Name               | Description                                  | Mandatory | Default value |
-|:-------------------|:---------------------------------------------|:----------|:--------------|
-| `token_url`        | OAuth 2 token URL.                           | Mandatory |               |
-| `username`         | Resource owner user name.                    | Mandatory |               |
-| `password`         | Resource owner password.                     | Mandatory |               |
-| `timeout`          | Maximum amount of seconds to wait for a token to be received once requested. | Optional | 60            |
-| `header_name`      | Name of the header field used to send token. | Optional  | Authorization |
-| `header_value`     | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
-| `scope`            | Scope parameter sent to token URL as body. Can also be a list of scopes. | Optional |  |
-| `token_field_name` | Field name containing the token.             | Optional  | access_token  |
-| `early_expiry`     | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
-| `client`           | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
+| Name                 | Description                                                                                                                                                                                                                                                                                       | Mandatory | Default value |
+|:---------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------|:--------------|
+| `token_url`          | OAuth 2 token URL.                                                                                                                                                                                                                                                                                | Mandatory |               |
+| `username`           | Resource owner user name.                                                                                                                                                                                                                                                                         | Mandatory |               |
+| `password`           | Resource owner password.                                                                                                                                                                                                                                                                          | Mandatory |               |
+| `client_auth`        | Client authentication if the client type is confidential or the client was issued client credentials (or assigned other authentication requirements). Can be a tuple or any httpx authentication class instance.                                                                                  | Optional  |               |
+| `timeout`            | Maximum amount of seconds to wait for a token to be received once requested.                                                                                                                                                                                                                      | Optional  | 60            |
+| `header_name`        | Name of the header field used to send token.                                                                                                                                                                                                                                                      | Optional  | Authorization |
+| `header_value`       | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token.                                                                                                                                                                                        | Optional  | Bearer {token} |
+| `scope`              | Scope parameter sent to token URL as body. Can also be a list of scopes.                                                                                                                                                                                                                          | Optional  |  |
+| `token_field_name`   | Field name containing the token.                                                                                                                                                                                                                                                                  | Optional  | access_token  |
+| `early_expiry`       | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
+| `client`             | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance.                                                                                                                                                                            | Optional  |  |
 
 Any other parameter will be put as body parameter in the token URL.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/httpx_auth/actions"><img alt="Build status" src="https://github.com/Colin-b/httpx_auth/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/httpx_auth/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/httpx_auth/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-307 passed-blue"></a>
+<a href="https://github.com/Colin-b/httpx_auth/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-335 passed-blue"></a>
 <a href="https://pypi.org/project/httpx-auth/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/httpx_auth"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Usual extra parameters are:
 | `client_secret`        | If client is not authenticated with the authorization server     |
 | `nonce`        | Refer to [OpenID ID Token specifications][3] for more details     |
 
-### Resource Owner Password Credentials flow 
+### Resource Owner Password Credentials flow
 
 Resource Owner Password Credentials Grant is implemented following [rfc6749](https://tools.ietf.org/html/rfc6749#section-4.3).
 
@@ -313,6 +313,48 @@ with httpx.Client() as client:
 | `client`             | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance.                                                                                                                                                                            | Optional  |  |
 
 Any other parameter will be put as body parameter in the token URL.
+
+#### Common providers
+
+Most of [OAuth2](https://oauth.net/2/) Resource Owner Password Credentials providers are supported.
+
+If the one you are looking for is not yet supported, feel free to [ask for its implementation](https://github.com/Colin-b/httpx_auth/issues/new).
+
+##### Okta (OAuth2 Resource Owner Password Credentials)
+
+[Okta Resource Owner Password Credentials](https://developer.okta.com/docs/guides/implement-grant-type/ropassword/main/) providing access tokens is supported.
+
+Use `httpx_auth.OktaResourceOwnerPasswordCredentials` to configure this kind of authentication.
+
+```python
+import httpx
+from httpx_auth import OktaResourceOwnerPasswordCredentials
+
+
+okta = OktaResourceOwnerPasswordCredentials(instance='testserver.okta-emea.com', username='user name', password='user password', client_id='54239d18-c68c-4c47-8bdd-ce71ea1d50cd', client_secret="0c5MB")
+with httpx.Client() as client:
+    client.get('https://www.example.com', auth=okta)
+```
+
+###### Parameters
+
+| Name                    | Description                | Mandatory | Default value |
+|:------------------------|:---------------------------|:----------|:--------------|
+| `instance`              | Okta instance (like "testserver.okta-emea.com"). | Mandatory |               |
+| `username`           | Resource owner user name.                                                                                                                                                                                                                                                                         | Mandatory |               |
+| `password`           | Resource owner password.                                                                                                                                                                                                                                                                          | Mandatory |               |
+| `client_id`             | Okta Application Identifier (formatted as an Universal Unique Identifier). | Mandatory |               |
+| `client_secret`        | Resource owner password.     | Mandatory |               |
+| `timeout`               | Maximum amount of seconds to wait for a token to be received once requested. | Optional | 60 |
+| `header_name`           | Name of the header field used to send token. | Optional | Authorization |
+| `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
+| `scope`                 | Scope parameter sent in query. Can also be a list of scopes. | Optional | openid |
+| `token_field_name`      | Field name containing the token. | Optional | access_token |
+| `early_expiry`          | Number of seconds before actual token expiry where token will be considered as expired. Used to ensure token will not expire between the time of retrieval and the time the request reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry. | Optional  | 30.0  |
+| `client`                | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
+
+Any other parameter will be put as body parameters in the token URL.        
+
 
 ### Client Credentials flow
 

--- a/httpx_auth/__init__.py
+++ b/httpx_auth/__init__.py
@@ -15,6 +15,7 @@ from httpx_auth.authentication import (
     OAuth2ClientCredentials,
     OktaClientCredentials,
     OAuth2ResourceOwnerPasswordCredentials,
+    OktaResourceOwnerPasswordCredentials,
     WakaTimeAuthorizationCode,
 )
 from httpx_auth.oauth2_tokens import JsonTokenFileCache
@@ -47,6 +48,7 @@ __all__ = [
     "OAuth2ClientCredentials",
     "OktaClientCredentials",
     "OAuth2ResourceOwnerPasswordCredentials",
+    "OktaResourceOwnerPasswordCredentials",
     "WakaTimeAuthorizationCode",
     "JsonTokenFileCache",
     "AWS4Auth",

--- a/httpx_auth/authentication.py
+++ b/httpx_auth/authentication.py
@@ -149,6 +149,9 @@ class OAuth2ResourceOwnerPasswordCredentials(httpx.Auth, SupportMultiAuth):
         :param token_url: OAuth 2 token URL.
         :param username: Resource owner user name.
         :param password: Resource owner password.
+        :param client_auth: Client authentication if the client type is confidential
+        or the client was issued client credentials (or assigned other authentication requirements).
+        Can be a tuple or any httpx authentication class instance.
         :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
         Wait for 1 minute by default.
         :param header_name: Name of the header field used to send token.
@@ -186,6 +189,7 @@ class OAuth2ResourceOwnerPasswordCredentials(httpx.Auth, SupportMultiAuth):
         # Time is expressed in seconds
         self.timeout = int(kwargs.pop("timeout", None) or 60)
         self.client = kwargs.pop("client", None)
+        self.client_auth = kwargs.pop("client_auth", None)
 
         # As described in https://tools.ietf.org/html/rfc6749#section-4.3.2
         self.data = {
@@ -228,7 +232,8 @@ class OAuth2ResourceOwnerPasswordCredentials(httpx.Auth, SupportMultiAuth):
         return (self.state, token, expires_in) if expires_in else (self.state, token)
 
     def _configure_client(self, client: httpx.Client):
-        client.auth = (self.username, self.password)
+        if self.client_auth:
+            client.auth = self.client_auth
         client.timeout = self.timeout
 
 

--- a/httpx_auth/authentication.py
+++ b/httpx_auth/authentication.py
@@ -1228,6 +1228,64 @@ class OktaClientCredentials(OAuth2ClientCredentials):
         )
 
 
+class OktaResourceOwnerPasswordCredentials(OAuth2ResourceOwnerPasswordCredentials):
+    """
+    Describes an Okta (OAuth 2) resource owner password credentials (also called password) flow requests authentication.
+    """
+
+    def __init__(
+        self,
+        instance: str,
+        username: str,
+        password: str,
+        client_id: str,
+        client_secret: str,
+        **kwargs,
+    ):
+        """
+        :param instance: Okta instance (like "testserver.okta-emea.com")
+        :param username: Resource owner user name.
+        :param password: Resource owner password.
+        :param client_id: Okta Application Identifier (formatted as an Universal Unique Identifier)
+        :param client_secret: Resource owner password.
+        :param authorization_server: Okta authorization server
+        default by default.
+        :param timeout: Maximum amount of seconds to wait for a token to be received once requested.
+        Wait for 1 minute by default.
+        :param header_name: Name of the header field used to send token.
+        Token will be sent in Authorization header field by default.
+        :param header_value: Format used to send the token value.
+        "{token}" must be present as it will be replaced by the actual token.
+        Token will be sent as "Bearer {token}" by default.
+        :param scope: Scope parameter sent to token URL as body. Can also be a list of scopes.
+        Request 'openid' by default.
+        :param token_field_name: Field name containing the token. access_token by default.
+        :param early_expiry: Number of seconds before actual token expiry where token will be considered as expired.
+        Default to 30 seconds to ensure token will not expire between the time of retrieval and the time the request
+        reaches the actual server. Set it to 0 to deactivate this feature and use the same token until actual expiry.
+        :param client: httpx.Client instance that will be used to request the token.
+        Use it to provide a custom proxying rule for instance.
+        :param kwargs: all additional authorization parameters that should be put as body parameters in the token URL.
+        """
+        if not instance:
+            raise Exception("Instance is mandatory.")
+        if not client_id:
+            raise Exception("Client ID is mandatory.")
+        if not client_secret:
+            raise Exception("Client secret is mandatory.")
+        authorization_server = kwargs.pop("authorization_server", None) or "default"
+        scopes = kwargs.pop("scope", "openid")
+        kwargs["scope"] = " ".join(scopes) if isinstance(scopes, list) else scopes
+        OAuth2ResourceOwnerPasswordCredentials.__init__(
+            self,
+            f"https://{instance}/oauth2/{authorization_server}/v1/token",
+            username=username,
+            password=password,
+            client_auth=(client_id, client_secret),
+            **kwargs,
+        )
+
+
 class HeaderApiKey(httpx.Auth, SupportMultiAuth):
     """Describes an API Key requests authentication."""
 

--- a/httpx_auth/version.py
+++ b/httpx_auth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.16.0"
+__version__ = "0.17.0"

--- a/tests/test_oauth2_resource_owner_password_okta.py
+++ b/tests/test_oauth2_resource_owner_password_okta.py
@@ -1,0 +1,630 @@
+import time
+
+from pytest_httpx import HTTPXMock
+import pytest
+import httpx
+
+import httpx_auth
+from tests.auth_helper import get_header
+from httpx_auth.testing import token_cache
+
+
+def test_oauth2_password_credentials_flow_uses_provided_client(
+    token_cache, httpx_mock: HTTPXMock
+):
+    client = httpx.Client(headers={"x-test": "Test value"})
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+        client=client,
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"grant_type=password&username=test_user&password=test_pwd&scope=openid",
+        match_headers={
+            "x-test": "Test value",
+            "Authorization": "Basic dGVzdF91c2VyMjp0ZXN0X3B3ZDI=",
+        },
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
+def test_oauth2_password_credentials_flow_is_able_to_reuse_client(
+    token_cache, httpx_mock: HTTPXMock
+):
+    client = httpx.Client(headers={"x-test": "Test value"})
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+        client=client,
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 10,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"grant_type=password&username=test_user&password=test_pwd&scope=openid",
+        match_headers={
+            "x-test": "Test value",
+            "Authorization": "Basic dGVzdF91c2VyMjp0ZXN0X3B3ZDI=",
+        },
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+    time.sleep(10)
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
+def test_oauth2_password_credentials_flow_token_is_sent_in_authorization_header_by_default(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"grant_type=password&username=test_user&password=test_pwd&scope=openid",
+        match_headers={"Authorization": "Basic dGVzdF91c2VyMjp0ZXN0X3B3ZDI="},
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
+def test_oauth2_password_credentials_flow_token_is_expired_after_30_seconds_by_default(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    # Add a token that expires in 29 seconds, so should be considered as expired when issuing the request
+    token_cache._add_token(
+        key="bdc39831ac59c0f65d36761e9b65656ae76223f2284c393a6e93fe4e09a2c0002e2638bbe02db2cc62928a2357be5e2e93b9fa4ac68729f4d28da180caae912a",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    # Meaning a new one will be requested
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"grant_type=password&username=test_user&password=test_pwd&scope=openid",
+        match_headers={"Authorization": "Basic dGVzdF91c2VyMjp0ZXN0X3B3ZDI="},
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
+def test_oauth2_password_credentials_flow_token_custom_expiry(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+        early_expiry=28,
+    )
+    # Add a token that expires in 29 seconds, so should be considered as not expired when issuing the request
+    token_cache._add_token(
+        key="bdc39831ac59c0f65d36761e9b65656ae76223f2284c393a6e93fe4e09a2c0002e2638bbe02db2cc62928a2357be5e2e93b9fa4ac68729f4d28da180caae912a",
+        token="2YotnFZFEjr1zCsicMWpAA",
+        expiry=httpx_auth.oauth2_tokens._to_expiry(expires_in=29),
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
+def test_expires_in_sent_as_str(token_cache, httpx_mock: HTTPXMock):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": "3600",
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"grant_type=password&username=test_user&password=test_pwd&scope=openid",
+        match_headers={"Authorization": "Basic dGVzdF91c2VyMjp0ZXN0X3B3ZDI="},
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
+def test_scope_is_sent_as_is_when_provided_as_str(token_cache, httpx_mock: HTTPXMock):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+        scope="my_scope+my_other_scope",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"grant_type=password&username=test_user&password=test_pwd&scope=my_scope%2Bmy_other_scope",
+        match_headers={"Authorization": "Basic dGVzdF91c2VyMjp0ZXN0X3B3ZDI="},
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
+def test_scope_is_sent_as_str_when_provided_as_list(token_cache, httpx_mock: HTTPXMock):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+        scope=["my_scope", "my_other_scope"],
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"grant_type=password&username=test_user&password=test_pwd&scope=my_scope+my_other_scope",
+        match_headers={"Authorization": "Basic dGVzdF91c2VyMjp0ZXN0X3B3ZDI="},
+    )
+    assert (
+        get_header(httpx_mock, auth).get("Authorization")
+        == "Bearer 2YotnFZFEjr1zCsicMWpAA"
+    )
+
+
+def test_with_invalid_grant_request_no_json(token_cache, httpx_mock: HTTPXMock):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        text="failure",
+        status_code=400,
+    )
+    with pytest.raises(httpx_auth.InvalidGrantRequest) as exception_info:
+        httpx.get("https://authorized_only", auth=auth)
+    assert str(exception_info.value) == "failure"
+
+
+def test_with_invalid_grant_request_invalid_request_error(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={"error": "invalid_request"},
+        status_code=400,
+    )
+    with pytest.raises(httpx_auth.InvalidGrantRequest) as exception_info:
+        httpx.get("https://authorized_only", auth=auth)
+    assert (
+        str(exception_info.value)
+        == "invalid_request: The request is missing a required parameter, includes an "
+        "unsupported parameter value (other than grant type), repeats a parameter, "
+        "includes multiple credentials, utilizes more than one mechanism for "
+        "authenticating the client, or is otherwise malformed."
+    )
+
+
+def test_with_invalid_grant_request_invalid_request_error_and_error_description(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={"error": "invalid_request", "error_description": "desc of the error"},
+        status_code=400,
+    )
+    with pytest.raises(httpx_auth.InvalidGrantRequest) as exception_info:
+        httpx.get("https://authorized_only", auth=auth)
+    assert str(exception_info.value) == "invalid_request: desc of the error"
+
+
+def test_with_invalid_grant_request_invalid_request_error_and_error_description_and_uri(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "error": "invalid_request",
+            "error_description": "desc of the error",
+            "error_uri": "https://test_url",
+        },
+        status_code=400,
+    )
+    with pytest.raises(httpx_auth.InvalidGrantRequest) as exception_info:
+        httpx.get("https://authorized_only", auth=auth)
+    assert (
+        str(exception_info.value)
+        == f"invalid_request: desc of the error\nMore information can be found on https://test_url"
+    )
+
+
+def test_with_invalid_grant_request_invalid_request_error_and_error_description_and_uri_and_other_fields(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "error": "invalid_request",
+            "error_description": "desc of the error",
+            "error_uri": "https://test_url",
+            "other": "other info",
+        },
+        status_code=400,
+    )
+    with pytest.raises(httpx_auth.InvalidGrantRequest) as exception_info:
+        httpx.get("https://authorized_only", auth=auth)
+    assert (
+        str(exception_info.value)
+        == f"invalid_request: desc of the error\nMore information can be found on https://test_url\nAdditional information: {{'other': 'other info'}}"
+    )
+
+
+def test_with_invalid_grant_request_without_error(token_cache, httpx_mock: HTTPXMock):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={"other": "other info"},
+        status_code=400,
+    )
+    with pytest.raises(httpx_auth.InvalidGrantRequest) as exception_info:
+        httpx.get("https://authorized_only", auth=auth)
+    assert str(exception_info.value) == "{'other': 'other info'}"
+
+
+def test_with_invalid_grant_request_invalid_client_error(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={"error": "invalid_client"},
+        status_code=400,
+    )
+    with pytest.raises(httpx_auth.InvalidGrantRequest) as exception_info:
+        httpx.get("https://authorized_only", auth=auth)
+    assert (
+        str(exception_info.value)
+        == "invalid_client: Client authentication failed (e.g., unknown client, no "
+        "client authentication included, or unsupported authentication method).  The "
+        "authorization server MAY return an HTTP 401 (Unauthorized) status code to "
+        "indicate which HTTP authentication schemes are supported.  If the client "
+        'attempted to authenticate via the "Authorization" request header field, the '
+        "authorization server MUST respond with an HTTP 401 (Unauthorized) status "
+        'code and include the "WWW-Authenticate" response header field matching the '
+        "authentication scheme used by the client."
+    )
+
+
+def test_with_invalid_grant_request_invalid_grant_error(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={"error": "invalid_grant"},
+        status_code=400,
+    )
+    with pytest.raises(httpx_auth.InvalidGrantRequest) as exception_info:
+        httpx.get("https://authorized_only", auth=auth)
+    assert (
+        str(exception_info.value)
+        == "invalid_grant: The provided authorization grant (e.g., authorization code, "
+        "resource owner credentials) or refresh token is invalid, expired, revoked, "
+        "does not match the redirection URI used in the authorization request, or was "
+        "issued to another client."
+    )
+
+
+def test_with_invalid_grant_request_unauthorized_client_error(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={"error": "unauthorized_client"},
+        status_code=400,
+    )
+    with pytest.raises(httpx_auth.InvalidGrantRequest) as exception_info:
+        httpx.get("https://authorized_only", auth=auth)
+    assert (
+        str(exception_info.value)
+        == "unauthorized_client: The authenticated client is not authorized to use this "
+        "authorization grant type."
+    )
+
+
+def test_with_invalid_grant_request_unsupported_grant_type_error(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={"error": "unsupported_grant_type"},
+        status_code=400,
+    )
+    with pytest.raises(httpx_auth.InvalidGrantRequest) as exception_info:
+        httpx.get("https://authorized_only", auth=auth)
+    assert (
+        str(exception_info.value)
+        == "unsupported_grant_type: The authorization grant type is not supported by the "
+        "authorization server."
+    )
+
+
+def test_with_invalid_grant_request_invalid_scope_error(
+    token_cache, httpx_mock: HTTPXMock
+):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={"error": "invalid_scope"},
+        status_code=400,
+    )
+    with pytest.raises(httpx_auth.InvalidGrantRequest) as exception_info:
+        httpx.get("https://authorized_only", auth=auth)
+    assert (
+        str(exception_info.value)
+        == "invalid_scope: The requested scope is invalid, unknown, malformed, or "
+        "exceeds the scope granted by the resource owner."
+    )
+
+
+def test_without_expected_token(token_cache, httpx_mock: HTTPXMock):
+    auth = httpx_auth.OktaResourceOwnerPasswordCredentials(
+        "testserver.okta-emea.com",
+        username="test_user",
+        password="test_pwd",
+        client_id="test_user2",
+        client_secret="test_pwd2",
+        token_field_name="not_provided",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://testserver.okta-emea.com/oauth2/default/v1/token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+    )
+    with pytest.raises(httpx_auth.GrantNotProvided) as exception_info:
+        httpx.get("https://authorized_only", auth=auth)
+    assert (
+        str(exception_info.value)
+        == "not_provided not provided within {'access_token': '2YotnFZFEjr1zCsicMWpAA', 'token_type': 'example', 'expires_in': 3600, 'refresh_token': 'tGzv3JOkF0XG5Qx2TlKWIA', 'example_parameter': 'example_value'}."
+    )
+
+
+def test_instance_is_mandatory():
+    with pytest.raises(Exception) as exception_info:
+        httpx_auth.OktaResourceOwnerPasswordCredentials(
+            "",
+            "test_user",
+            "test_pwd",
+            client_id="test_user2",
+            client_secret="test_pwd2",
+        )
+    assert str(exception_info.value) == "Instance is mandatory."
+
+
+def test_user_name_is_mandatory():
+    with pytest.raises(Exception) as exception_info:
+        httpx_auth.OktaResourceOwnerPasswordCredentials(
+            "https://test_url",
+            "",
+            "test_pwd",
+            client_id="test_user2",
+            client_secret="test_pwd2",
+        )
+    assert str(exception_info.value) == "User name is mandatory."
+
+
+def test_password_is_mandatory():
+    with pytest.raises(Exception) as exception_info:
+        httpx_auth.OktaResourceOwnerPasswordCredentials(
+            "https://test_url",
+            "test_user",
+            "",
+            client_id="test_user2",
+            client_secret="test_pwd2",
+        )
+    assert str(exception_info.value) == "Password is mandatory."
+
+
+def test_client_id_is_mandatory():
+    with pytest.raises(Exception) as exception_info:
+        httpx_auth.OktaResourceOwnerPasswordCredentials(
+            "https://test_url",
+            "test_user",
+            "test_pwd",
+            client_id="",
+            client_secret="test_pwd2",
+        )
+    assert str(exception_info.value) == "Client ID is mandatory."
+
+
+def test_client_secret_is_mandatory():
+    with pytest.raises(Exception) as exception_info:
+        httpx_auth.OktaResourceOwnerPasswordCredentials(
+            "https://test_url",
+            "test_user",
+            "test_pwd",
+            client_id="test_user2",
+            client_secret="",
+        )
+    assert str(exception_info.value) == "Client secret is mandatory."
+
+
+def test_header_value_must_contains_token():
+    with pytest.raises(Exception) as exception_info:
+        httpx_auth.OktaResourceOwnerPasswordCredentials(
+            "https://test_url",
+            "test_user",
+            "test_pwd",
+            client_id="test_user2",
+            client_secret="test_pwd2",
+            header_value="Bearer token",
+        )
+    assert str(exception_info.value) == "header_value parameter must contains {token}."


### PR DESCRIPTION
### Changed
- `httpx_auth.OAuth2ResourceOwnerPasswordCredentials` does not send basic authentication by default.

### Added
- `client_auth` as a parameter of `httpx_auth.OAuth2ResourceOwnerPasswordCredentials`. Allowing to provide any kind of optional authentication.
- `httpx_auth.OktaResourceOwnerPasswordCredentials` providing Okta resource owner password credentials flow easy setup.

closes #54 