### PR TITLE
Release 0.18.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2023-09-11
+### Changed
+- Requires [`httpx`](https://www.python-httpx.org)==0.25.\*
+
+### Removed
+- Python 3.8 is no longer supported.
+
 ## [0.17.0] - 2023-04-26
 ### Changed
 - `httpx_auth.OAuth2ResourceOwnerPasswordCredentials` does not send basic authentication by default.
@@ -178,7 +185,8 @@ Note that a few changes were made:
 ### Added
 - Placeholder for port of requests_auth to httpx
 
-[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/Colin-b/httpx_auth/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/Colin-b/httpx_auth/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Colin-b/httpx_auth/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/Colin-b/httpx_auth/compare/v0.14.1...v0.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.17.0] - 2023-04-26
 ### Changed
 - `httpx_auth.OAuth2ResourceOwnerPasswordCredentials` does not send basic authentication by default.
 
@@ -176,7 +178,8 @@ Note that a few changes were made:
 ### Added
 - Placeholder for port of requests_auth to httpx
 
-[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/Colin-b/httpx_auth/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Colin-b/httpx_auth/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/Colin-b/httpx_auth/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/Colin-b/httpx_auth/compare/v0.14.0...v0.14.1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/Colin-b/httpx_auth/actions"><img alt="Build status" src="https://github.com/Colin-b/httpx_auth/workflows/Release/badge.svg"></a>
 <a href="https://github.com/Colin-b/httpx_auth/actions"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://github.com/Colin-b/httpx_auth/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-307 passed-blue"></a>
+<a href="https://github.com/Colin-b/httpx_auth/actions"><img alt="Number of tests" src="https://img.shields.io/badge/tests-335 passed-blue"></a>
 <a href="https://pypi.org/project/httpx-auth/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/httpx_auth"></a>
 </p>
 

--- a/httpx_auth/version.py
+++ b/httpx_auth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.17.0"
+__version__ = "0.18.0"

--- a/httpx_auth/version.py
+++ b/httpx_auth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.16.0"
+__version__ = "0.17.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "httpx_auth"
 description = "Authentication for HTTPX"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 authors = [
     {name = "Colin Bounouar", email = "colin.bounouar.dev@gmail.com" }
@@ -23,14 +23,13 @@ classifiers=[
     "Typing :: Typed",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: Software Development :: Build Tools",
 ]
 dependencies = [
-    "httpx==0.24.*",
+    "httpx==0.25.*",
 ]
 dynamic = ["version"]
 
@@ -45,7 +44,7 @@ testing = [
     # Used to generate test tokens
     "pyjwt==2.*",
     # Used to mock httpx
-    "pytest_httpx==0.22.*",
+    "pytest_httpx==0.25.*",
     # Used to check coverage
     "pytest-cov==4.*",
 ]


### PR DESCRIPTION
### Changed
- Requires [`httpx`](https://www.python-httpx.org)==0.25.\*

### Removed
- Python 3.8 is no longer supported.
