### PR TITLE
Add support for httpx>=0.23.0 & python >=3.8, <=3.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.8','3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,17 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.8','3.9', '3.10', '3.11', '3.12']
+        httpx-version: ['0.25.0', '0.24.1', '0.23.3']
+        include:
+          - httpx-version: '0.25.0'
+            pytest-httpx-version: '0.26.0'
+          - httpx-version: '0.24.1'
+            pytest-httpx-version: '0.23.1'
+          - httpx-version: '0.23.3'
+            pytest-httpx-version: '0.21.3'
 
     steps:
     - uses: actions/checkout@v4
@@ -19,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .[testing]
+        python -m pip install httpx==${{ matrix.httpx-version }} pyjwt pytest_httpx==${{ matrix.pytest-httpx-version }} pytest-cov
     - name: Test with pytest
       run: |
         pytest --cov=httpx_auth --cov-fail-under=100 --cov-report=term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "httpx_auth"
 description = "Authentication for HTTPX"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 authors = [
     {name = "Colin Bounouar", email = "colin.bounouar.dev@gmail.com" }
@@ -23,13 +23,15 @@ classifiers=[
     "Typing :: Typed",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Build Tools",
 ]
 dependencies = [
-    "httpx==0.25.*",
+    "httpx>=0.23.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Thanks for bringing this project! 

I should be awesome to support a wider range of versions of Python and httpx. In my opinion the version constraints are to restrictive. The same applies to `pytest_httpx`. If `pytest_httpx` loses its version constraints we can get Python 3.8 succeeding for all versions. 

See here for the outcome of the actions pipeline: https://github.com/foarsitter/httpx_auth/actions/runs/6677590996