### PR TITLE
Release 0.19.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -23,3 +23,7 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov=httpx_auth --cov-fail-under=100 --cov-report=term-missing
+    - name: Create packages
+      run: |
+        python -m pip install build
+        python -m build .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.12.1
     hooks:
       - id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2024-01-09
+### Added
+- Explicit support for Python 3.12
+
+### Changed
+- Requires [`httpx`](https://www.python-httpx.org)==0.26.\*
+  - Note that this changes the signature sent via AWS auth for URLs containing %. Feel free to open an issue if this is one.
+
 ## [0.18.0] - 2023-09-11
 ### Changed
 - Requires [`httpx`](https://www.python-httpx.org)==0.25.\*
@@ -185,7 +193,8 @@ Note that a few changes were made:
 ### Added
 - Placeholder for port of requests_auth to httpx
 
-[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/Colin-b/httpx_auth/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/Colin-b/httpx_auth/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/Colin-b/httpx_auth/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/Colin-b/httpx_auth/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Colin-b/httpx_auth/compare/v0.15.0...v0.16.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Colin Bounouar
+Copyright (c) 2024 Colin Bounouar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/httpx_auth/version.py
+++ b/httpx_auth/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.18.0"
+__version__ = "0.19.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,11 @@ classifiers=[
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Build Tools",
 ]
 dependencies = [
-    "httpx==0.25.*, httpx==0.26.*",
+    "httpx==0.26.*",
 ]
 dynamic = ["version"]
 
@@ -44,7 +45,7 @@ testing = [
     # Used to generate test tokens
     "pyjwt==2.*",
     # Used to mock httpx
-    "pytest_httpx==0.25.*",
+    "pytest_httpx==0.28.*",
     # Used to check coverage
     "pytest-cov==4.*",
 ]

--- a/tests/test_aws4auth.py
+++ b/tests/test_aws4auth.py
@@ -250,7 +250,7 @@ def test_aws_auth_path_percent_encode_non_s3(httpx_mock: HTTPXMock, mock_aws_dat
         service="iam",
     )
     httpx_mock.add_response(
-        url="https://authorized_only/test/%252a%252b%2525/~-_%5E&%20%25%25"
+        url="https://authorized_only/test/%2a%2b%25/~-_%5E&%20%25%25"
     )
 
     httpx.post("https://authorized_only/test/%2a%2b%25/~-_^& %%", auth=auth)
@@ -261,7 +261,7 @@ def test_aws_auth_path_percent_encode_non_s3(httpx_mock: HTTPXMock, mock_aws_dat
     )
     assert (
         headers["Authorization"]
-        == "AWS4-HMAC-SHA256 Credential=access_id/20181011/us-east-1/iam/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=289c2090b71ada48944fbf204e99cf305effeb54b87932215dc7b2b6a3203722"
+        == "AWS4-HMAC-SHA256 Credential=access_id/20181011/us-east-1/iam/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=7b3267f1b4bcb1f6731eb99aa9b3381225c18fc32e3ecb78fc4adceb746f92f3"
     )
     assert headers["x-amz-date"] == "20181011T150505Z"
 
@@ -274,7 +274,7 @@ def test_aws_auth_path_percent_encode_s3(httpx_mock: HTTPXMock, mock_aws_datetim
         service="s3",
     )
     httpx_mock.add_response(
-        url="https://authorized_only/test/%252a%252b%2525/~-_%5E&%20%25%25"
+        url="https://authorized_only/test/%2a%2b%25/~-_%5E&%20%25%25"
     )
 
     httpx.post("https://authorized_only/test/%2a%2b%25/~-_^& %%", auth=auth)
@@ -285,7 +285,7 @@ def test_aws_auth_path_percent_encode_s3(httpx_mock: HTTPXMock, mock_aws_datetim
     )
     assert (
         headers["Authorization"]
-        == "AWS4-HMAC-SHA256 Credential=access_id/20181011/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=2fc7c2f27151e18348862bab0bbe90c4a9f29d7863a33e725d7b1ec96709fdd6"
+        == "AWS4-HMAC-SHA256 Credential=access_id/20181011/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=dd3e44f87a05d1488fa5aca66702e8c53a0d0fa570564bc70941bc5c6d25016d"
     )
     assert headers["x-amz-date"] == "20181011T150505Z"
 


### PR DESCRIPTION
### Added
- Explicit support for Python 3.12

### Changed
- Requires [`httpx`](https://www.python-httpx.org)==0.26.\*
  - Note that this changes the signature sent via AWS auth for URLs containing %. Feel free to open an issue if this is one.
