### PR TITLE
Custom auth code templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ with httpx.Client() as client:
 | `timeout`               | Maximum amount of seconds to wait for a code or a token to be received once requested. | Optional | 60 |
 | `success_display_time`  | In case a code is successfully received, this is the maximum amount of milliseconds the success page will be displayed in your browser. | Optional | 1 |
 | `failure_display_time`  | In case received code is not valid, this is the maximum amount of milliseconds the failure page will be displayed in your browser. | Optional | 5000 |
+| `success_template`      | HTML content to render to the browser upon successfully receiving an authorization code from the authorization server. Will be formatted with `text` and `display_time` parameters. | Optional |  |
+| `failure_template`      | HTML content to render to the browser upon successfully receiving an authorization code from the authorization server. Will be formatted with `text` and `display_time` parameters. | Optional |  |
 | `header_name`           | Name of the header field used to send token. | Optional | Authorization |
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `response_type`         | Value of the response_type query parameter if not already provided in authorization URL. | Optional | code |
@@ -137,6 +139,8 @@ with httpx.Client() as client:
 | `timeout`               | Maximum amount of seconds to wait for a token to be received once requested. | Optional | 60 |
 | `success_display_time`  | In case a token is successfully received, this is the maximum amount of milliseconds the success page will be displayed in your browser. | Optional | 1 |
 | `failure_display_time`  | In case received token is not valid, this is the maximum amount of milliseconds the failure page will be displayed in your browser. | Optional | 5000 |
+| `success_template`      | HTML content to render to the browser upon successfully receiving an authorization code from the authorization server. Will be formatted with `text` and `display_time` parameters. | Optional |  |
+| `failure_template`      | HTML content to render to the browser upon successfully receiving an authorization code from the authorization server. Will be formatted with `text` and `display_time` parameters. | Optional |  |
 | `header_name`           | Name of the header field used to send token. | Optional | Authorization |
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `client`                | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |
@@ -181,6 +185,8 @@ with httpx.Client() as client:
 | `timeout`               | Maximum amount of seconds to wait for a token to be received once requested. | Optional  | 60                                           |
 | `success_display_time`  | In case a token is successfully received, this is the maximum amount of milliseconds the success page will be displayed in your browser. | Optional  | 1                                            |
 | `failure_display_time`  | In case received token is not valid, this is the maximum amount of milliseconds the failure page will be displayed in your browser. | Optional  | 5000                                         |
+| `success_template`      | HTML content to render to the browser upon successfully receiving an authorization code from the authorization server. Will be formatted with `text` and `display_time` parameters. | Optional |  |
+| `failure_template`      | HTML content to render to the browser upon successfully receiving an authorization code from the authorization server. Will be formatted with `text` and `display_time` parameters. | Optional |  |
 | `header_name`           | Name of the header field used to send token. | Optional  | Authorization                                |
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional  | Bearer {token}                               |
 | `client`                | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional  |                                              |
@@ -212,6 +218,8 @@ with httpx.Client() as client:
 | `timeout`               | Maximum amount of seconds to wait for a code or a token to be received once requested. | Optional | 60 |
 | `success_display_time`  | In case a code is successfully received, this is the maximum amount of milliseconds the success page will be displayed in your browser. | Optional | 1 |
 | `failure_display_time`  | In case received code is not valid, this is the maximum amount of milliseconds the failure page will be displayed in your browser. | Optional | 5000 |
+| `success_template`      | HTML content to render to the browser upon successfully receiving an authorization code from the authorization server. Will be formatted with `text` and `display_time` parameters. | Optional |  |
+| `failure_template`      | HTML content to render to the browser upon successfully receiving an authorization code from the authorization server. Will be formatted with `text` and `display_time` parameters. | Optional |  |
 | `header_name`           | Name of the header field used to send token. | Optional | Authorization |
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `response_type`         | Value of the response_type query parameter if not already provided in authorization URL. | Optional | code |
@@ -270,6 +278,8 @@ with httpx.Client() as client:
 | `timeout`               | Maximum amount of seconds to wait for a token to be received once requested. | Optional | 60 |
 | `success_display_time`  | In case a token is successfully received, this is the maximum amount of milliseconds the success page will be displayed in your browser. | Optional | 1 |
 | `failure_display_time`  | In case received token is not valid, this is the maximum amount of milliseconds the failure page will be displayed in your browser. | Optional | 5000 |
+| `success_template`      | HTML content to render to the browser upon successfully receiving an authorization code from the authorization server. Will be formatted with `text` and `display_time` parameters. | Optional |  |
+| `failure_template`      | HTML content to render to the browser upon successfully receiving an authorization code from the authorization server. Will be formatted with `text` and `display_time` parameters. | Optional |  |
 | `header_name`           | Name of the header field used to send token. | Optional | Authorization |
 | `header_value`          | Format used to send the token value. "{token}" must be present as it will be replaced by the actual token. | Optional | Bearer {token} |
 | `client`                | `httpx.Client` instance that will be used to request the token. Use it to provide a custom proxying rule for instance. | Optional |  |

--- a/httpx_auth/authentication.py
+++ b/httpx_auth/authentication.py
@@ -358,6 +358,10 @@ class OAuth2AuthorizationCode(httpx.Auth, SupportMultiAuth, BrowserAuth):
         :param failure_display_time: In case received code is not valid,
         this is the maximum amount of milliseconds the failure page will be displayed in your browser.
         Display the page for 5 seconds by default.
+        :param success_template: HTML content to render to the browser upon successfully receiving an
+        authorization code from the authorization server. Will be formatted with 'text' and 'display_time' parameters.
+        :param failure_template: HTML content to render to the browser upon failing to receive an
+        authorization code from the authorization server. Will be formatted with 'text' and 'display_time' parameters.
         :param header_name: Name of the header field used to send token.
         Token will be sent in Authorization header field by default.
         :param header_value: Format used to send the token value.
@@ -388,6 +392,9 @@ class OAuth2AuthorizationCode(httpx.Auth, SupportMultiAuth, BrowserAuth):
         self.token_url = token_url
         if not self.token_url:
             raise Exception("Token URL is mandatory.")
+
+        success_template = kwargs.pop("success_template", None)
+        failure_template = kwargs.pop("failure_template", None)
 
         BrowserAuth.__init__(self, kwargs)
 
@@ -438,6 +445,8 @@ class OAuth2AuthorizationCode(httpx.Auth, SupportMultiAuth, BrowserAuth):
             self.success_display_time,
             self.failure_display_time,
             self.redirect_uri_port,
+            reception_success_template=success_template,
+            reception_failure_template=failure_template,
         )
 
         # As described in https://tools.ietf.org/html/rfc6749#section-4.1.3
@@ -514,6 +523,10 @@ class OAuth2AuthorizationCodePKCE(httpx.Auth, SupportMultiAuth, BrowserAuth):
         :param failure_display_time: In case received code is not valid,
         this is the maximum amount of milliseconds the failure page will be displayed in your browser.
         Display the page for 5 seconds by default.
+        :param success_template: HTML content to render to the browser upon successfully receiving an
+        authorization code from the authorization server. Will be formatted with 'text' and 'display_time' parameters.
+        :param failure_template: HTML content to render to the browser upon failing to receive an
+        authorization code from the authorization server. Will be formatted with 'text' and 'display_time' parameters.
         :param header_name: Name of the header field used to send token.
         Token will be sent in Authorization header field by default.
         :param header_value: Format used to send the token value.
@@ -542,6 +555,9 @@ class OAuth2AuthorizationCodePKCE(httpx.Auth, SupportMultiAuth, BrowserAuth):
         self.token_url = token_url
         if not self.token_url:
             raise Exception("Token URL is mandatory.")
+
+        success_template = kwargs.pop("success_template", None)
+        failure_template = kwargs.pop("failure_template", None)
 
         BrowserAuth.__init__(self, kwargs)
 
@@ -601,6 +617,8 @@ class OAuth2AuthorizationCodePKCE(httpx.Auth, SupportMultiAuth, BrowserAuth):
             self.success_display_time,
             self.failure_display_time,
             self.redirect_uri_port,
+            reception_success_template=success_template,
+            reception_failure_template=failure_template,
         )
 
         # As described in https://tools.ietf.org/html/rfc6749#section-4.1.3
@@ -1043,6 +1061,10 @@ class OktaAuthorizationCode(OAuth2AuthorizationCode):
         :param failure_display_time: In case received token is not valid,
         this is the maximum amount of milliseconds the failure page will be displayed in your browser.
         Display the page for 5 seconds by default.
+        :param success_template: HTML content to render to the browser upon successfully receiving an
+        authorization code from the authorization server. Will be formatted with 'text' and 'display_time' parameters.
+        :param failure_template: HTML content to render to the browser upon failing to receive an
+        authorization code from the authorization server. Will be formatted with 'text' and 'display_time' parameters.
         :param header_name: Name of the header field used to send token.
         Token will be sent in Authorization header field by default.
         :param header_value: Format used to send the token value.
@@ -1104,6 +1126,10 @@ class WakaTimeAuthorizationCode(OAuth2AuthorizationCode):
         :param failure_display_time: In case received token is not valid,
         this is the maximum amount of milliseconds the failure page will be displayed in your browser.
         Display the page for 5 seconds by default.
+        :param success_template: HTML content to render to the browser upon successfully receiving an
+        authorization code from the authorization server. Will be formatted with 'text' and 'display_time' parameters.
+        :param failure_template: HTML content to render to the browser upon failing to receive an
+        authorization code from the authorization server. Will be formatted with 'text' and 'display_time' parameters.
         :param header_name: Name of the header field used to send token.
         Token will be sent in Authorization header field by default.
         :param header_value: Format used to send the token value.
@@ -1162,6 +1188,10 @@ class OktaAuthorizationCodePKCE(OAuth2AuthorizationCodePKCE):
         :param failure_display_time: In case received token is not valid,
         this is the maximum amount of milliseconds the failure page will be displayed in your browser.
         Display the page for 5 seconds by default.
+        :param success_template: HTML content to render to the browser upon successfully receiving an
+        authorization code from the authorization server. Will be formatted with 'text' and 'display_time' parameters.
+        :param failure_template: HTML content to render to the browser upon failing to receive an
+        authorization code from the authorization server. Will be formatted with 'text' and 'display_time' parameters.
         :param header_name: Name of the header field used to send token.
         Token will be sent in Authorization header field by default.
         :param header_value: Format used to send the token value.

--- a/httpx_auth/oauth2_authentication_responses_server.py
+++ b/httpx_auth/oauth2_authentication_responses_server.py
@@ -129,6 +129,8 @@ class OAuth2ResponseHandler(BaseHTTPRequestHandler):
 
 class GrantDetails:
     DEFAULT_SUCCESS_TEMPLATE = """
+        <!DOCTYPE html>
+        <html>
         <body onload="window.open('', '_self', ''); window.setTimeout(close, {display_time})"
          style="color: #4F8A10;
                 background-color: #DFF2BF;
@@ -137,8 +139,11 @@ class GrantDetails:
                 align-items: center;
                 justify-content: center;">
             <div style="border: 1px solid; padding: 8px;">{text}</div>
-        </body>"""
+        </body>
+        </html>"""
     DEFAULT_FAILURE_TEMPLATE = """
+        <!DOCTYPE html>
+        <html>
         <body onload="window.open('', '_self', ''); window.setTimeout(close, {display_time})"
          style="color: #D8000C;
                 background-color: #FFBABA;
@@ -147,7 +152,8 @@ class GrantDetails:
                 align-items: center;
                 justify-content: center;">
             <div style="border: 1px solid; padding: 8px;">{text}</div>
-        </body>"""
+        </body>
+        </html>"""
 
     def __init__(
         self,

--- a/tests/oauth2/authorization_code/test_oauth2_authorization_code_sync.py
+++ b/tests/oauth2/authorization_code/test_oauth2_authorization_code_sync.py
@@ -48,6 +48,72 @@ def test_oauth2_authorization_code_flow_uses_provided_client(
     )
 
 
+def test_oauth2_authorization_code_flow_uses_custom_success_template(
+    token_cache, httpx_mock: HTTPXMock, browser_mock: BrowserMock
+):
+    success_template = (
+        "<body><div>SUCCESS: {display_time}</div><div>{text}</div></body>"
+    )
+    client = httpx.Client(headers={"x-test": "Test value"})
+    auth = httpx_auth.OAuth2AuthorizationCode(
+        "https://provide_code",
+        "https://provide_access_token",
+        client=client,
+        success_template=success_template,
+    )
+    tab = browser_mock.add_response(
+        opened_url="https://provide_code?response_type=code&state=ce9c755b41b5e3c5b64c70598715d5de271023a53f39a67a70215d265d11d2bfb6ef6e9c701701e998e69cbdbf2cee29fd51d2a950aa05f59a20cf4a646099d5&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F",
+        reply_url="http://localhost:5000#code=SplxlOBeZQQYbYS6WxSbIA&state=ce9c755b41b5e3c5b64c70598715d5de271023a53f39a67a70215d265d11d2bfb6ef6e9c701701e998e69cbdbf2cee29fd51d2a950aa05f59a20cf4a646099d5",
+        success_template=success_template,
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://provide_access_token",
+        json={
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "example",
+            "expires_in": 3600,
+            "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+            "example_parameter": "example_value",
+        },
+        match_content=b"grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F&response_type=code&code=SplxlOBeZQQYbYS6WxSbIA",
+        match_headers={"x-test": "Test value"},
+    )
+    httpx_mock.add_response(
+        match_headers={"Authorization": "Bearer 2YotnFZFEjr1zCsicMWpAA"}
+    )
+    # Send a request to this dummy URL with authentication
+    httpx.get("https://authorized_only", auth=auth)
+    tab.assert_success(
+        "You are now authenticated on ce9c755b41b5e3c5b64c70598715d5de271023a53f39a67a70215d265d11d2bfb6ef6e9c701701e998e69cbdbf2cee29fd51d2a950aa05f59a20cf4a646099d5. You may close this tab."
+    )
+
+
+def test_with_invalid_request_error_uses_custom_failure_template(
+    token_cache, browser_mock: BrowserMock
+):
+    failure_template = "FAILURE: {display_time}\n{text}"
+    auth = httpx_auth.OAuth2AuthorizationCode(
+        "https://provide_code",
+        "https://provide_access_token",
+        failure_template=failure_template,
+    )
+    tab = browser_mock.add_response(
+        opened_url="https://provide_code?response_type=code&state=ce9c755b41b5e3c5b64c70598715d5de271023a53f39a67a70215d265d11d2bfb6ef6e9c701701e998e69cbdbf2cee29fd51d2a950aa05f59a20cf4a646099d5&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2F",
+        reply_url="http://localhost:5000#error=invalid_request",
+        failure_template=failure_template,
+    )
+    with pytest.raises(httpx_auth.InvalidGrantRequest) as exception_info:
+        httpx.get("https://authorized_only", auth=auth)
+    assert (
+        str(exception_info.value)
+        == "invalid_request: The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed."
+    )
+    tab.assert_failure(
+        "Unable to properly perform authentication: invalid_request: The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed."
+    )
+
+
 def test_oauth2_authorization_code_flow_is_able_to_reuse_client(
     token_cache, httpx_mock: HTTPXMock, browser_mock: BrowserMock
 ):


### PR DESCRIPTION
Instead of hard-coding the HTML templates for the authorization code flow, expose them as options to `OAuth2AuthorizationCode` and all subclasses.

This allows users of this library to ensure that the templates match their site branding.

The new parameters are optional and default to values that are the exact same HTML as before.

I don't fully document what the default templates are, since I'm not really sure where the best place to do so would be.

Also added tests to ensure they work properly.