### PR TITLE
Refactor OAuth flows to use OAuth2 as a base class.

### DIFF
--- a/httpx_auth/_oauth2/authentication_responses_server.py
+++ b/httpx_auth/_oauth2/authentication_responses_server.py
@@ -166,7 +166,7 @@ class FixedHttpServer(HTTPServer):
         raise TimeoutOccurred(self.timeout)
 
 
-def request_new_grant(grant_details: GrantDetails) -> (str, str):
+def request_new_grant(grant_details: GrantDetails) -> tuple[str, str]:
     """
     Ask for a new OAuth2 grant.
     :return: A tuple (state, grant)

--- a/httpx_auth/_oauth2/authorization_code.py
+++ b/httpx_auth/_oauth2/authorization_code.py
@@ -71,10 +71,8 @@ class OAuth2AuthorizationCode(OAuth2BaseAuth, SupportMultiAuth, BrowserAuth):
 
         BrowserAuth.__init__(self, kwargs)
 
-        self.header_name = kwargs.pop("header_name", None) or "Authorization"
-        self.header_value = kwargs.pop("header_value", None) or "Bearer {token}"
-        if "{token}" not in self.header_value:
-            raise Exception("header_value parameter must contains {token}.")
+        header_name = kwargs.pop("header_name", None) or "Authorization"
+        header_value = kwargs.pop("header_value", None) or "Bearer {token}"
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
         early_expiry = float(kwargs.pop("early_expiry", None) or 30.0)
@@ -129,10 +127,14 @@ class OAuth2AuthorizationCode(OAuth2BaseAuth, SupportMultiAuth, BrowserAuth):
         self.refresh_data = {"grant_type": "refresh_token"}
         self.refresh_data.update(kwargs)
 
-        OAuth2BaseAuth.__init__(self, state, early_expiry, self.refresh_token)
-
-    def _update_user_request(self, request: httpx.Request, token: str) -> None:
-        request.headers[self.header_name] = self.header_value.format(token=token)
+        OAuth2BaseAuth.__init__(
+            self,
+            state,
+            early_expiry,
+            header_name,
+            header_value,
+            self.refresh_token,
+        )
 
     def request_new_token(self) -> tuple:
         # Request code

--- a/httpx_auth/_oauth2/authorization_code.py
+++ b/httpx_auth/_oauth2/authorization_code.py
@@ -1,5 +1,5 @@
 from hashlib import sha512
-from typing import Generator, Iterable, Union
+from typing import Iterable, Union
 
 import httpx
 
@@ -8,14 +8,14 @@ from httpx_auth._oauth2 import authentication_responses_server
 from httpx_auth._oauth2.browser import BrowserAuth
 from httpx_auth._oauth2.common import (
     request_new_grant_with_post,
-    OAuth2,
+    OAuth2BaseAuth,
     _add_parameters,
     _pop_parameter,
     _get_query_parameter,
 )
 
 
-class OAuth2AuthorizationCode(OAuth2, SupportMultiAuth, BrowserAuth):
+class OAuth2AuthorizationCode(OAuth2BaseAuth, SupportMultiAuth, BrowserAuth):
     """
     Authorization Code Grant
 
@@ -70,7 +70,7 @@ class OAuth2AuthorizationCode(OAuth2, SupportMultiAuth, BrowserAuth):
             raise Exception("Token URL is mandatory.")
 
         BrowserAuth.__init__(self, kwargs)
-        OAuth2.__init__(self)
+        OAuth2BaseAuth.__init__(self)
 
         self.header_name = kwargs.pop("header_name", None) or "Authorization"
         self.header_value = kwargs.pop("header_value", None) or "Bearer {token}"

--- a/httpx_auth/_oauth2/authorization_code_pkce.py
+++ b/httpx_auth/_oauth2/authorization_code_pkce.py
@@ -16,7 +16,7 @@ from httpx_auth._oauth2.common import (
 )
 
 
-class OAuth2AuthorizationCodePKCE(httpx.Auth, SupportMultiAuth, BrowserAuth):
+class OAuth2AuthorizationCodePKCE(OAuth2, SupportMultiAuth, BrowserAuth):
     """
     Proof Key for Code Exchange
 
@@ -69,6 +69,7 @@ class OAuth2AuthorizationCodePKCE(httpx.Auth, SupportMultiAuth, BrowserAuth):
             raise Exception("Token URL is mandatory.")
 
         BrowserAuth.__init__(self, kwargs)
+        OAuth2.__init__(self)
 
         self.client = kwargs.pop("client", None)
 
@@ -139,17 +140,8 @@ class OAuth2AuthorizationCodePKCE(httpx.Auth, SupportMultiAuth, BrowserAuth):
         self.refresh_data = {"grant_type": "refresh_token"}
         self.refresh_data.update(kwargs)
 
-    def auth_flow(
-        self, request: httpx.Request
-    ) -> Generator[httpx.Request, httpx.Response, None]:
-        token = OAuth2.token_cache.get_token(
-            self.state,
-            early_expiry=self.early_expiry,
-            on_missing_token=self.request_new_token,
-            on_expired_token=self.refresh_token,
-        )
+    def _update_user_request(self, request: httpx.Request, token: str) -> None:
         request.headers[self.header_name] = self.header_value.format(token=token)
-        yield request
 
     def request_new_token(self) -> tuple:
         # Request code

--- a/httpx_auth/_oauth2/authorization_code_pkce.py
+++ b/httpx_auth/_oauth2/authorization_code_pkce.py
@@ -1,7 +1,6 @@
 import base64
 import os
 from hashlib import sha256, sha512
-from typing import Generator
 
 import httpx
 
@@ -10,13 +9,13 @@ from httpx_auth._oauth2 import authentication_responses_server
 from httpx_auth._oauth2.browser import BrowserAuth
 from httpx_auth._oauth2.common import (
     request_new_grant_with_post,
-    OAuth2,
+    OAuth2BaseAuth,
     _add_parameters,
     _pop_parameter,
 )
 
 
-class OAuth2AuthorizationCodePKCE(OAuth2, SupportMultiAuth, BrowserAuth):
+class OAuth2AuthorizationCodePKCE(OAuth2BaseAuth, SupportMultiAuth, BrowserAuth):
     """
     Proof Key for Code Exchange
 
@@ -69,7 +68,7 @@ class OAuth2AuthorizationCodePKCE(OAuth2, SupportMultiAuth, BrowserAuth):
             raise Exception("Token URL is mandatory.")
 
         BrowserAuth.__init__(self, kwargs)
-        OAuth2.__init__(self)
+        OAuth2BaseAuth.__init__(self)
 
         self.client = kwargs.pop("client", None)
 

--- a/httpx_auth/_oauth2/authorization_code_pkce.py
+++ b/httpx_auth/_oauth2/authorization_code_pkce.py
@@ -71,10 +71,8 @@ class OAuth2AuthorizationCodePKCE(OAuth2BaseAuth, SupportMultiAuth, BrowserAuth)
 
         self.client = kwargs.pop("client", None)
 
-        self.header_name = kwargs.pop("header_name", None) or "Authorization"
-        self.header_value = kwargs.pop("header_value", None) or "Bearer {token}"
-        if "{token}" not in self.header_value:
-            raise Exception("header_value parameter must contains {token}.")
+        header_name = kwargs.pop("header_name", None) or "Authorization"
+        header_value = kwargs.pop("header_value", None) or "Bearer {token}"
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
         early_expiry = float(kwargs.pop("early_expiry", None) or 30.0)
@@ -138,10 +136,9 @@ class OAuth2AuthorizationCodePKCE(OAuth2BaseAuth, SupportMultiAuth, BrowserAuth)
         self.refresh_data = {"grant_type": "refresh_token"}
         self.refresh_data.update(kwargs)
 
-        OAuth2BaseAuth.__init__(self, state, early_expiry, self.refresh_token)
-
-    def _update_user_request(self, request: httpx.Request, token: str) -> None:
-        request.headers[self.header_name] = self.header_value.format(token=token)
+        OAuth2BaseAuth.__init__(
+            self, state, early_expiry, header_name, header_value, self.refresh_token
+        )
 
     def request_new_token(self) -> tuple:
         # Request code

--- a/httpx_auth/_oauth2/client_credentials.py
+++ b/httpx_auth/_oauth2/client_credentials.py
@@ -49,15 +49,13 @@ class OAuth2ClientCredentials(OAuth2BaseAuth, SupportMultiAuth):
         if not self.client_secret:
             raise Exception("client_secret is mandatory.")
 
-        super().__init__()
-
         self.header_name = kwargs.pop("header_name", None) or "Authorization"
         self.header_value = kwargs.pop("header_value", None) or "Bearer {token}"
         if "{token}" not in self.header_value:
             raise Exception("header_value parameter must contains {token}.")
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
-        self.early_expiry = float(kwargs.pop("early_expiry", None) or 30.0)
+        early_expiry = float(kwargs.pop("early_expiry", None) or 30.0)
 
         # Time is expressed in seconds
         self.timeout = int(kwargs.pop("timeout", None) or 60)
@@ -72,7 +70,9 @@ class OAuth2ClientCredentials(OAuth2BaseAuth, SupportMultiAuth):
         self.data.update(kwargs)
 
         all_parameters_in_url = _add_parameters(self.token_url, self.data)
-        self.state = sha512(all_parameters_in_url.encode("unicode_escape")).hexdigest()
+        state = sha512(all_parameters_in_url.encode("unicode_escape")).hexdigest()
+
+        super().__init__(state, early_expiry)
 
     def _update_user_request(self, request: httpx.Request, token: str) -> None:
         request.headers[self.header_name] = self.header_value.format(token=token)

--- a/httpx_auth/_oauth2/client_credentials.py
+++ b/httpx_auth/_oauth2/client_credentials.py
@@ -49,10 +49,8 @@ class OAuth2ClientCredentials(OAuth2BaseAuth, SupportMultiAuth):
         if not self.client_secret:
             raise Exception("client_secret is mandatory.")
 
-        self.header_name = kwargs.pop("header_name", None) or "Authorization"
-        self.header_value = kwargs.pop("header_value", None) or "Bearer {token}"
-        if "{token}" not in self.header_value:
-            raise Exception("header_value parameter must contains {token}.")
+        header_name = kwargs.pop("header_name", None) or "Authorization"
+        header_value = kwargs.pop("header_value", None) or "Bearer {token}"
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
         early_expiry = float(kwargs.pop("early_expiry", None) or 30.0)
@@ -72,10 +70,12 @@ class OAuth2ClientCredentials(OAuth2BaseAuth, SupportMultiAuth):
         all_parameters_in_url = _add_parameters(self.token_url, self.data)
         state = sha512(all_parameters_in_url.encode("unicode_escape")).hexdigest()
 
-        super().__init__(state, early_expiry)
-
-    def _update_user_request(self, request: httpx.Request, token: str) -> None:
-        request.headers[self.header_name] = self.header_value.format(token=token)
+        super().__init__(
+            state,
+            early_expiry,
+            header_name,
+            header_value,
+        )
 
     def request_new_token(self) -> tuple:
         client = self.client or httpx.Client()

--- a/httpx_auth/_oauth2/client_credentials.py
+++ b/httpx_auth/_oauth2/client_credentials.py
@@ -1,16 +1,16 @@
 from hashlib import sha512
-from typing import Generator, Union, Iterable
+from typing import Union, Iterable
 
 import httpx
 from httpx_auth._authentication import SupportMultiAuth
 from httpx_auth._oauth2.common import (
-    OAuth2,
+    OAuth2BaseAuth,
     request_new_grant_with_post,
     _add_parameters,
 )
 
 
-class OAuth2ClientCredentials(OAuth2, SupportMultiAuth):
+class OAuth2ClientCredentials(OAuth2BaseAuth, SupportMultiAuth):
     """
     Client Credentials Grant
 

--- a/httpx_auth/_oauth2/common.py
+++ b/httpx_auth/_oauth2/common.py
@@ -91,10 +91,20 @@ class OAuth2:
 
 class OAuth2BaseAuth(abc.ABC, httpx.Auth):
     def __init__(
-        self, state: str, early_expiry: float, refresh_token: Optional[Callable] = None
+        self,
+        state: str,
+        early_expiry: float,
+        header_name: str,
+        header_value: str,
+        refresh_token: Optional[Callable] = None,
     ) -> None:
+        if "{token}" not in header_value:
+            raise Exception("header_value parameter must contains {token}.")
+
         self.state = state
         self.early_expiry = early_expiry
+        self.header_name = header_name
+        self.header_value = header_value
         self.refresh_token = refresh_token
 
     def auth_flow(
@@ -113,6 +123,5 @@ class OAuth2BaseAuth(abc.ABC, httpx.Auth):
     def request_new_token(self) -> Union[tuple[str, str], tuple[str, str, int]]:
         pass  # pragma: no cover
 
-    @abc.abstractmethod
     def _update_user_request(self, request: httpx.Request, token: str) -> None:
-        pass  # pragma: no cover
+        request.headers[self.header_name] = self.header_value.format(token=token)

--- a/httpx_auth/_oauth2/common.py
+++ b/httpx_auth/_oauth2/common.py
@@ -90,10 +90,12 @@ class OAuth2:
 
 
 class OAuth2BaseAuth(abc.ABC, httpx.Auth):
-    state: Optional[str] = None
-    early_expiry: float
-
-    refresh_token: Optional[Callable]
+    def __init__(
+        self, state: str, early_expiry: float, refresh_token: Optional[Callable] = None
+    ) -> None:
+        self.state = state
+        self.early_expiry = early_expiry
+        self.refresh_token = refresh_token
 
     def auth_flow(
         self, request: httpx.Request
@@ -102,9 +104,7 @@ class OAuth2BaseAuth(abc.ABC, httpx.Auth):
             self.state,
             early_expiry=self.early_expiry,
             on_missing_token=self.request_new_token,
-            on_expired_token=(
-                self.refresh_token if "refresh_token" in dir(self) else None
-            ),
+            on_expired_token=self.refresh_token,
         )
         self._update_user_request(request, token)
         yield request

--- a/httpx_auth/_oauth2/common.py
+++ b/httpx_auth/_oauth2/common.py
@@ -84,9 +84,12 @@ def request_new_grant_with_post(
     return token, content.get("expires_in"), content.get("refresh_token")
 
 
-class OAuth2(abc.ABC, httpx.Auth):
+class OAuth2:
     token_cache = TokenMemoryCache()
     display = DisplaySettings()
+
+
+class OAuth2BaseAuth(abc.ABC, httpx.Auth):
     state: Optional[str] = None
     early_expiry: float
 

--- a/httpx_auth/_oauth2/implicit.py
+++ b/httpx_auth/_oauth2/implicit.py
@@ -61,10 +61,8 @@ class OAuth2Implicit(OAuth2BaseAuth, SupportMultiAuth, BrowserAuth):
 
         BrowserAuth.__init__(self, kwargs)
 
-        self.header_name = kwargs.pop("header_name", None) or "Authorization"
-        self.header_value = kwargs.pop("header_value", None) or "Bearer {token}"
-        if "{token}" not in self.header_value:
-            raise Exception("header_value parameter must contains {token}.")
+        header_name = kwargs.pop("header_name", None) or "Authorization"
+        header_value = kwargs.pop("header_value", None) or "Bearer {token}"
 
         response_type = _get_query_parameter(self.authorization_url, "response_type")
         if response_type:
@@ -103,10 +101,13 @@ class OAuth2Implicit(OAuth2BaseAuth, SupportMultiAuth, BrowserAuth):
             self.redirect_uri_port,
         )
 
-        OAuth2BaseAuth.__init__(self, state, early_expiry)
-
-    def _update_user_request(self, request: httpx.Request, token: str) -> None:
-        request.headers[self.header_name] = self.header_value.format(token=token)
+        OAuth2BaseAuth.__init__(
+            self,
+            state,
+            early_expiry,
+            header_name,
+            header_value,
+        )
 
     def request_new_token(self) -> tuple[str, str]:
         return authentication_responses_server.request_new_grant(self.grant_details)

--- a/httpx_auth/_oauth2/implicit.py
+++ b/httpx_auth/_oauth2/implicit.py
@@ -1,6 +1,5 @@
 import uuid
 from hashlib import sha512
-from typing import Generator, Union
 
 import httpx
 
@@ -8,14 +7,14 @@ from httpx_auth._authentication import SupportMultiAuth
 from httpx_auth._oauth2 import authentication_responses_server
 from httpx_auth._oauth2.browser import BrowserAuth
 from httpx_auth._oauth2.common import (
-    OAuth2,
+    OAuth2BaseAuth,
     _add_parameters,
     _pop_parameter,
     _get_query_parameter,
 )
 
 
-class OAuth2Implicit(OAuth2, SupportMultiAuth, BrowserAuth):
+class OAuth2Implicit(OAuth2BaseAuth, SupportMultiAuth, BrowserAuth):
     """
     Implicit Grant
 
@@ -61,7 +60,7 @@ class OAuth2Implicit(OAuth2, SupportMultiAuth, BrowserAuth):
             raise Exception("Authorization URL is mandatory.")
 
         BrowserAuth.__init__(self, kwargs)
-        OAuth2.__init__(self)
+        OAuth2BaseAuth.__init__(self)
 
         self.header_name = kwargs.pop("header_name", None) or "Authorization"
         self.header_value = kwargs.pop("header_value", None) or "Bearer {token}"

--- a/httpx_auth/_oauth2/resource_owner_password.py
+++ b/httpx_auth/_oauth2/resource_owner_password.py
@@ -41,7 +41,7 @@ class OAuth2ResourceOwnerPasswordCredentials(OAuth2BaseAuth, SupportMultiAuth):
         Use it to provide a custom proxying rule for instance.
         :param kwargs: all additional authorization parameters that should be put as body parameters in the token URL.
         """
-        super().__init__()
+        OAuth2BaseAuth.__init__(self)
 
         self.token_url = token_url
         if not self.token_url:

--- a/httpx_auth/_oauth2/resource_owner_password.py
+++ b/httpx_auth/_oauth2/resource_owner_password.py
@@ -41,7 +41,6 @@ class OAuth2ResourceOwnerPasswordCredentials(OAuth2BaseAuth, SupportMultiAuth):
         Use it to provide a custom proxying rule for instance.
         :param kwargs: all additional authorization parameters that should be put as body parameters in the token URL.
         """
-        OAuth2BaseAuth.__init__(self)
 
         self.token_url = token_url
         if not self.token_url:
@@ -59,7 +58,7 @@ class OAuth2ResourceOwnerPasswordCredentials(OAuth2BaseAuth, SupportMultiAuth):
             raise Exception("header_value parameter must contains {token}.")
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
-        self.early_expiry = float(kwargs.pop("early_expiry", None) or 30.0)
+        early_expiry = float(kwargs.pop("early_expiry", None) or 30.0)
 
         # Time is expressed in seconds
         self.timeout = int(kwargs.pop("timeout", None) or 60)
@@ -84,7 +83,9 @@ class OAuth2ResourceOwnerPasswordCredentials(OAuth2BaseAuth, SupportMultiAuth):
         self.refresh_data.update(kwargs)
 
         all_parameters_in_url = _add_parameters(self.token_url, self.data)
-        self.state = sha512(all_parameters_in_url.encode("unicode_escape")).hexdigest()
+        state = sha512(all_parameters_in_url.encode("unicode_escape")).hexdigest()
+
+        OAuth2BaseAuth.__init__(self, state, early_expiry, self.refresh_token)
 
     def _update_user_request(self, request: httpx.Request, token: str) -> None:
         request.headers[self.header_name] = self.header_value.format(token=token)

--- a/httpx_auth/_oauth2/resource_owner_password.py
+++ b/httpx_auth/_oauth2/resource_owner_password.py
@@ -3,13 +3,13 @@ from hashlib import sha512
 import httpx
 from httpx_auth._authentication import SupportMultiAuth
 from httpx_auth._oauth2.common import (
-    OAuth2,
+    OAuth2BaseAuth,
     request_new_grant_with_post,
     _add_parameters,
 )
 
 
-class OAuth2ResourceOwnerPasswordCredentials(OAuth2, SupportMultiAuth):
+class OAuth2ResourceOwnerPasswordCredentials(OAuth2BaseAuth, SupportMultiAuth):
     """
     Resource Owner Password Credentials Grant
 

--- a/httpx_auth/_oauth2/resource_owner_password.py
+++ b/httpx_auth/_oauth2/resource_owner_password.py
@@ -52,10 +52,8 @@ class OAuth2ResourceOwnerPasswordCredentials(OAuth2BaseAuth, SupportMultiAuth):
         if not self.password:
             raise Exception("Password is mandatory.")
 
-        self.header_name = kwargs.pop("header_name", None) or "Authorization"
-        self.header_value = kwargs.pop("header_value", None) or "Bearer {token}"
-        if "{token}" not in self.header_value:
-            raise Exception("header_value parameter must contains {token}.")
+        header_name = kwargs.pop("header_name", None) or "Authorization"
+        header_value = kwargs.pop("header_value", None) or "Bearer {token}"
 
         self.token_field_name = kwargs.pop("token_field_name", None) or "access_token"
         early_expiry = float(kwargs.pop("early_expiry", None) or 30.0)
@@ -85,10 +83,14 @@ class OAuth2ResourceOwnerPasswordCredentials(OAuth2BaseAuth, SupportMultiAuth):
         all_parameters_in_url = _add_parameters(self.token_url, self.data)
         state = sha512(all_parameters_in_url.encode("unicode_escape")).hexdigest()
 
-        OAuth2BaseAuth.__init__(self, state, early_expiry, self.refresh_token)
-
-    def _update_user_request(self, request: httpx.Request, token: str) -> None:
-        request.headers[self.header_name] = self.header_value.format(token=token)
+        OAuth2BaseAuth.__init__(
+            self,
+            state,
+            early_expiry,
+            header_name,
+            header_value,
+            self.refresh_token,
+        )
 
     def request_new_token(self) -> tuple:
         client = self.client or httpx.Client()

--- a/httpx_auth/_oauth2/tokens.py
+++ b/httpx_auth/_oauth2/tokens.py
@@ -114,7 +114,6 @@ class TokenMemoryCache:
         early_expiry: float = 30.0,
         on_missing_token=None,
         on_expired_token=None,
-        **on_missing_token_kwargs,
     ) -> str:
         """
         Return the bearer token.
@@ -126,7 +125,6 @@ class TokenMemoryCache:
         expired 30 seconds before real expiry by default.
         :param on_missing_token: function to call when token is expired or missing (returning token and expiry tuple)
         :param on_expired_token: function to call to refresh the token when it is expired
-        :param on_missing_token_kwargs: arguments of the on_missing_token function (key-value arguments)
         :return: the token
         :raise AuthenticationFailed: in case token cannot be retrieved.
         """
@@ -171,7 +169,7 @@ class TokenMemoryCache:
         logger.debug("Token cannot be found in cache.")
         if on_missing_token is not None:
             with self._forbid_concurrent_missing_token_function_call:
-                new_token = on_missing_token(**on_missing_token_kwargs)
+                new_token = on_missing_token()
                 if len(new_token) == 2:  # Bearer token
                     state, token = new_token
                     self._add_bearer_token(state, token)


### PR DESCRIPTION
This change makes OAuth2 the base class for all OAuth2 related flow implementations.

In the future it may be used to handle locking and other IO in sync or async modes as per the httpx auth protocol.

Classes that also inherit from BrowserAuth currently don't use cooperative multiple inheritance. They should, but I thought I'd rather make it a separate change.

Prelude to #72 