### PR TITLE
Fix JSONDecodeError due to Improper Handling of Nested JSON Strings in JWT Payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix `JSONDecodeError` due to Improper Handling of Nested JSON Strings in JWT Payloads
 
 ## [0.22.0] - 2024-03-02
 ### Changed

--- a/httpx_auth/_oauth2/tokens.py
+++ b/httpx_auth/_oauth2/tokens.py
@@ -28,7 +28,7 @@ def decode_base64(base64_encoded_string: str) -> str:
     missing_padding = len(base64_encoded_string) % 4
     if missing_padding != 0:
         base64_encoded_string += "=" * (4 - missing_padding)
-    return base64.b64decode(base64_encoded_string).decode("unicode_escape")
+    return base64.urlsafe_b64decode(base64_encoded_string).decode("utf-8")
 
 
 def is_expired(expiry: float, early_expiry: float) -> bool:

--- a/tests/oauth2/tokens/test_tokens.py
+++ b/tests/oauth2/tokens/test_tokens.py
@@ -1,0 +1,30 @@
+import json
+import jwt
+
+from httpx_auth._oauth2.tokens import decode_base64
+
+
+def test_decode_base64():
+    # Encode a JSON inside the JWT
+    dummy_token = jwt.encode({"name": "John"}, key="")
+    header, body, signature = dummy_token.split(".")
+
+    # Decode the body
+    decoded_bytes = decode_base64(body)
+
+    # Attempt to load JSON
+    result = json.loads(decoded_bytes)
+    assert result == {"name": "John"}
+
+
+def test_decode_base64_with_nested_json_string():
+    # Encode a JSON inside the JWT
+    dummy_token = jwt.encode({"data": json.dumps({"something": ["else"]})}, key="")
+    header, body, signature = dummy_token.split(".")
+
+    # Decode the body
+    decoded_bytes = decode_base64(body)
+
+    # Attempt to load JSON
+    result = json.loads(decoded_bytes)
+    assert result == {"data": '{"something": ["else"]}'}


### PR DESCRIPTION
## Description

This PR addresses an issue in the `decode_base64` function where nested JSON strings within JWT tokens were being corrupted due to incorrect decoding of base64 strings that are not URL-safe. This corruption occurred because the original decoding was not handling certain characters properly, leading to JSON decoding errors when attempting to parse these strings back into JSON objects.

## Changes

- Replaced `base64.b64decode` with `base64.urlsafe_b64decode` to correctly handle base64 strings that include URL-safe characters.
- Changed decoding from "unicode_escape" to "utf-8" to prevent the misinterpretation of escape sequences in JSON strings.

## Previous Behavior

Previously, when JWT tokens contained nested JSON strings encoded in base64, the `decode_base64` function would sometimes corrupt these strings. This was particularly apparent when characters like '+' and '/' were included in the base64 string, which were not correctly handled by the standard `base64.b64decode`. The JSON parser would then fail to parse the string due to misplaced or altered characters.

For example, decoding a JWT payload with nested JSON would lead to a `JSONDecodeError`:

```python
import jwt
import json
from httpx_auth import decode_base64

# Original code
def test_decode_base64_with_unsafe_chars():
    dummy_token = jwt.encode({"data": json.dumps({"something": ["else"]})}, key="")
    header, body, signature = dummy_token.split(".")
    decoded_bytes = decode_base64(body)  # This would corrupt the JSON
    result = json.loads(decoded_bytes)
    assert result == {"data": '{"something": ["else"]}'}
```

## New Behavior
With the new changes, the decode_base64 function correctly decodes the base64 string without corrupting the JSON structure:

```python
import jwt
import json
from httpx_auth import decode_base64

# Updated code
def test_decode_base64_with_unsafe_chars():
    dummy_token = jwt.encode({"data": json.dumps({"something": ["else"]})}, key="")
    header, body, signature = dummy_token.split(".")
    decoded_bytes = decode_base64(body)  # Correctly decodes the JSON
    result = json.loads(decoded_bytes)
    assert result == {"data": {"something": ["else"]}}
```
This fix ensures that JWT tokens with nested JSON can be handled without errors, improving the robustness of the authentication handling in applications using **httpx-auth**.

## Additional Notes
This update is crucial for applications that depend on precise and error-free handling of JWT tokens, especially in scenarios involving complex data structures within the token payloads.

Closes #92 
