### PR TITLE
Make MultiAuth public API.

### DIFF
--- a/httpx_auth/__init__.py
+++ b/httpx_auth/__init__.py
@@ -1,6 +1,7 @@
 from httpx_auth._authentication import (
     Basic,
     HeaderApiKey,
+    MultiAuth,
     QueryApiKey,
     SupportMultiAuth,
 )
@@ -63,6 +64,7 @@ __all__ = [
     "OAuth2ResourceOwnerPasswordCredentials",
     "OktaResourceOwnerPasswordCredentials",
     "WakaTimeAuthorizationCode",
+    "MultiAuth",
     "SupportMultiAuth",
     "JsonTokenFileCache",
     "TokenMemoryCache",

--- a/httpx_auth/_authentication.py
+++ b/httpx_auth/_authentication.py
@@ -3,7 +3,7 @@ from typing import Generator
 import httpx
 
 
-class _MultiAuth(httpx.Auth):
+class MultiAuth(httpx.Auth):
     """Authentication using multiple authentication methods."""
 
     def __init__(self, *authentication_modes):
@@ -16,29 +16,29 @@ class _MultiAuth(httpx.Auth):
             next(authentication_mode.auth_flow(request))
         yield request
 
-    def __add__(self, other) -> "_MultiAuth":
-        if isinstance(other, _MultiAuth):
-            return _MultiAuth(*self.authentication_modes, *other.authentication_modes)
-        return _MultiAuth(*self.authentication_modes, other)
+    def __add__(self, other) -> "MultiAuth":
+        if isinstance(other, MultiAuth):
+            return MultiAuth(*self.authentication_modes, *other.authentication_modes)
+        return MultiAuth(*self.authentication_modes, other)
 
-    def __and__(self, other) -> "_MultiAuth":
-        if isinstance(other, _MultiAuth):
-            return _MultiAuth(*self.authentication_modes, *other.authentication_modes)
-        return _MultiAuth(*self.authentication_modes, other)
+    def __and__(self, other) -> "MultiAuth":
+        if isinstance(other, MultiAuth):
+            return MultiAuth(*self.authentication_modes, *other.authentication_modes)
+        return MultiAuth(*self.authentication_modes, other)
 
 
 class SupportMultiAuth:
     """Inherit from this class to be able to use your class with httpx_auth provided authentication classes."""
 
-    def __add__(self, other) -> _MultiAuth:
-        if isinstance(other, _MultiAuth):
-            return _MultiAuth(self, *other.authentication_modes)
-        return _MultiAuth(self, other)
+    def __add__(self, other) -> MultiAuth:
+        if isinstance(other, MultiAuth):
+            return MultiAuth(self, *other.authentication_modes)
+        return MultiAuth(self, other)
 
-    def __and__(self, other) -> _MultiAuth:
-        if isinstance(other, _MultiAuth):
-            return _MultiAuth(self, *other.authentication_modes)
-        return _MultiAuth(self, other)
+    def __and__(self, other) -> MultiAuth:
+        if isinstance(other, MultiAuth):
+            return MultiAuth(self, *other.authentication_modes)
+        return MultiAuth(self, other)
 
 
 class HeaderApiKey(httpx.Auth, SupportMultiAuth):


### PR DESCRIPTION
httpx-auth supports combining auth flows, which is currently handled by implementing SupportsMultiAuth interface. But internally all it does it uses MultiAuth to combine all those Auth instances into one.

This PR exposes MultiAuth, so that any Auth implementation can be directly used as part of this mechanism, e.g. httpx.auth.Digest or any custom Auth classes implemented by users.