### PR TITLE
SUGGESTION - oAuth encoding

### DIFF
--- a/httpx_auth/_oauth2/client_credentials.py
+++ b/httpx_auth/_oauth2/client_credentials.py
@@ -3,6 +3,8 @@ from hashlib import sha512
 from typing import Union, Iterable
 
 import httpx
+import urllib.parse
+
 from httpx_auth._authentication import SupportMultiAuth
 from httpx_auth._oauth2.common import (
     OAuth2BaseAuth,
@@ -97,7 +99,10 @@ class OAuth2ClientCredentials(OAuth2BaseAuth, SupportMultiAuth):
         return (self.state, token, expires_in) if expires_in else (self.state, token)
 
     def _configure_client(self, client: httpx.Client):
-        client.auth = (self.client_id, self.client_secret)
+        encoded_client = urllib.parse.quote(self.client_id, safe="")
+        encoded_secret = urllib.parse.quote(self.client_secret, safe="")
+
+        client.auth = (encoded_client, encoded_secret)
         client.timeout = self.timeout
 
 


### PR DESCRIPTION
oAuth requires client ID and secret to be urlencoded. 

When passing unencoded secrets that contain a + the current version will return a fail as a plus char can either be a space or a plus. According to the latest standards for oAuth clientID and secrets should be passed urlEncoded.

Ref: https://datatracker.ietf.org/doc/html/rfc6749#appendix-B